### PR TITLE
Fix robot naming

### DIFF
--- a/onshape-to-robot.py
+++ b/onshape-to-robot.py
@@ -14,9 +14,11 @@ from load_robot import \
 
 # Creating robot for output
 if config['outputFormat'] == 'urdf':
-    robot = RobotURDF()
+    robot = RobotURDF(config['robotName'])
+    robot.additionalXML = config['additionalUrdf']
 elif config['outputFormat'] == 'sdf':
-    robot = RobotSDF()
+    robot = RobotSDF(config['robotName'])
+    robot.additionalXML = config['additionalSdf']
 else:
     print(Fore.RED + 'ERROR: Unknown output format: '+config['outputFormat']+' (supported are urdf and sdf)' + Style.RESET_ALL)
     exit()
@@ -29,7 +31,6 @@ robot.jointMaxVelocity = config['jointMaxVelocity']
 robot.noDynamics = config['noDynamics']
 robot.packageName = config['packageName']
 robot.addDummyBaseLink = config['addDummyBaseLink']
-robot.robotName = config['robotName']
 
 
 # Adds a part to the current robot link

--- a/onshape-to-robot.py
+++ b/onshape-to-robot.py
@@ -15,10 +15,8 @@ from load_robot import \
 # Creating robot for output
 if config['outputFormat'] == 'urdf':
     robot = RobotURDF(config['robotName'])
-    robot.additionalXML = config['additionalUrdf']
 elif config['outputFormat'] == 'sdf':
     robot = RobotSDF(config['robotName'])
-    robot.additionalXML = config['additionalSdf']
 else:
     print(Fore.RED + 'ERROR: Unknown output format: '+config['outputFormat']+' (supported are urdf and sdf)' + Style.RESET_ALL)
     exit()

--- a/robot_description.py
+++ b/robot_description.py
@@ -283,7 +283,6 @@ class RobotURDF(RobotDescription):
         self.append('')
     
     def finalize(self):
-        self.append(self.additionalXML)
         self.append('</robot>')
 
 
@@ -439,6 +438,5 @@ class RobotSDF(RobotDescription):
         # print('Joint from: '+linkFrom+' to: '+linkTo+', transform: '+str(transform))
     
     def finalize(self):
-        self.append(self.additionalXML)
         self.append('</model>')
         self.append('</sdf>')

--- a/robot_description.py
+++ b/robot_description.py
@@ -42,7 +42,7 @@ def pose(matrix, frame = ''):
     return sdf % (x, y, z, rpy[0], rpy[1], rpy[2])
 
 class RobotDescription(object):
-    def __init__(self):
+    def __init__(self, name):
         self.drawCollisions = False
         self.relative = True
         self.mergeSTLs = False
@@ -54,8 +54,8 @@ class RobotDescription(object):
         self.noDynamics = False
         self.packageName = ""
         self.addDummyBaseLink = False
-        self.robotName = "onshape"
-    
+        self.robotName = name
+
     def append(self, str):
         self.xml += str+"\n"
 
@@ -133,8 +133,8 @@ class RobotDescription(object):
         return mass, com, inertia
 
 class RobotURDF(RobotDescription):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, name):
+        super().__init__(name)
         self.ext = 'urdf'
         self.append('<robot name="' + self.robotName + '">')
         pass
@@ -283,12 +283,13 @@ class RobotURDF(RobotDescription):
         self.append('')
     
     def finalize(self):
+        self.append(self.additionalXML)
         self.append('</robot>')
 
 
 class RobotSDF(RobotDescription):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, name):
+        super().__init__(name)
         self.ext = 'sdf'
         self.relative = False
         self.append('<sdf version="1.6">')
@@ -438,5 +439,6 @@ class RobotSDF(RobotDescription):
         # print('Joint from: '+linkFrom+' to: '+linkTo+', transform: '+str(transform))
     
     def finalize(self):
+        self.append(self.additionalXML)
         self.append('</model>')
         self.append('</sdf>')


### PR DESCRIPTION
This is a small fix for the feature of naming the model file.
It didn't work correctly before, since the name was written into the file in the init method but it was set afterwards.