### PR TITLE
Feature additional xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ Then edit `config.json` in your repository, here are the entries:
   as they often need to specify their robot_description package.
 * `addDummyBaseLink` adds a base_link without inertia as root. This is often necessary for ROS users
 * `robotName` specifies the robot name.
-* 'additionalUrdfFile' specifies a file with xml content that is inserted into the URDF. 
-  Useful to add things that can't be modelled in onshape.
-* 'additionalSdfFile' the same but for the SDF output.
+* `additionalUrdfFile` specifies a file with xml content that is inserted into the URDF at the end of the file. 
+  Useful to add things that can't be modelled in onshape, e.g. simulated sensors.
+* `additionalSdfFile` the same but for the SDF output.
 
 Here is an example of configuration:
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Then edit `config.json` in your repository, here are the entries:
 * `robotName` specifies the robot name.
 * `additionalUrdfFile` specifies a file with xml content that is inserted into the URDF at the end of the file. 
   Useful to add things that can't be modelled in onshape, e.g. simulated sensors.
-* `additionalSdfFile` the same but for the SDF output.
+* `additionalSdfFile` the same but for the SDF output. The XML content is added inside the <model> part.
 
 Here is an example of configuration:
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Then edit `config.json` in your repository, here are the entries:
   as they often need to specify their robot_description package.
 * `addDummyBaseLink` adds a base_link without inertia as root. This is often necessary for ROS users
 * `robotName` specifies the robot name.
+* 'additionalUrdfFile' specifies a file with xml content that is inserted into the URDF. 
+  Useful to add things that can't be modelled in onshape.
+* 'additionalSdfFile' the same but for the SDF output.
 
 Here is an example of configuration:
 

--- a/config.py
+++ b/config.py
@@ -58,19 +58,16 @@ config['addDummyBaseLink'] = configGet('addDummyBaseLink', False)
 config['robotName'] = configGet('robotName', 'onshape')
 
 # additional XML code to insert
-urdfFileName = configGet('additionalUrdfFile', '')
-if urdfFileName == '':
-    config['additionalUrdf'] = ''
+if config['outputFormat'] == 'urdf':
+    additionalFileName = configGet('additionalUrdfFile', '')
 else:
-    with open(robot + urdfFileName, 'r') as urdfFile:
-        config['additionalUrdf'] = urdfFile.read()
-        
-SdfFileName = configGet('additionalSdfFile', '')
-if SdfFileName == '':
-    config['additionalSdf'] = ''
+    additionalFileName = configGet('additionalSdfFile', '')
+
+if additionalFileName == '':
+    config['additionalXML'] = ''
 else:
-    with open(robot + SdfFileName, 'r') as SdfFile:
-        config['additionalSdf'] = SdfFile.read()
+    with open(robot + additionalFileName, 'r') as additionalXMLFile:
+        config['additionalXML'] = additionalXMLFile.read()
 
 
 # Creating dynamics override array

--- a/config.py
+++ b/config.py
@@ -57,6 +57,22 @@ config['packageName'] = configGet('packageName', '')
 config['addDummyBaseLink'] = configGet('addDummyBaseLink', False)
 config['robotName'] = configGet('robotName', 'onshape')
 
+# additional XML code to insert
+urdfFileName = configGet('additionalUrdfFile', '')
+if urdfFileName == '':
+    config['additionalUrdf'] = ''
+else:
+    with open(robot + urdfFileName, 'r') as urdfFile:
+        config['additionalUrdf'] = urdfFile.read()
+        
+SdfFileName = configGet('additionalSdfFile', '')
+if SdfFileName == '':
+    config['additionalSdf'] = ''
+else:
+    with open(robot + SdfFileName, 'r') as SdfFile:
+        config['additionalSdf'] = SdfFile.read()
+
+
 # Creating dynamics override array
 tmp = configGet('dynamics', {})
 for key in tmp:

--- a/onshape-to-robot.py
+++ b/onshape-to-robot.py
@@ -15,8 +15,10 @@ from load_robot import \
 # Creating robot for output
 if config['outputFormat'] == 'urdf':
     robot = RobotURDF()
+    robot.additionalXML = config['additionalUrdf']
 elif config['outputFormat'] == 'sdf':
     robot = RobotSDF()
+    robot.additionalXML = config['additionalSdf']
 else:
     print(Fore.RED + 'ERROR: Unknown output format: '+config['outputFormat']+' (supported are urdf and sdf)' + Style.RESET_ALL)
     exit()

--- a/onshape-to-robot.py
+++ b/onshape-to-robot.py
@@ -15,10 +15,8 @@ from load_robot import \
 # Creating robot for output
 if config['outputFormat'] == 'urdf':
     robot = RobotURDF()
-    robot.additionalXML = config['additionalUrdf']
 elif config['outputFormat'] == 'sdf':
     robot = RobotSDF()
-    robot.additionalXML = config['additionalSdf']
 else:
     print(Fore.RED + 'ERROR: Unknown output format: '+config['outputFormat']+' (supported are urdf and sdf)' + Style.RESET_ALL)
     exit()
@@ -32,7 +30,7 @@ robot.noDynamics = config['noDynamics']
 robot.packageName = config['packageName']
 robot.addDummyBaseLink = config['addDummyBaseLink']
 robot.robotName = config['robotName']
-
+robot.additionalXML = config['additionalXML']
 
 # Adds a part to the current robot link
 def addPart(occurrence, matrix):

--- a/robot_description.py
+++ b/robot_description.py
@@ -283,6 +283,7 @@ class RobotURDF(RobotDescription):
         self.append('')
     
     def finalize(self):
+        self.append(self.additionalXML)
         self.append('</robot>')
 
 
@@ -438,5 +439,6 @@ class RobotSDF(RobotDescription):
         # print('Joint from: '+linkFrom+' to: '+linkTo+', transform: '+str(transform))
     
     def finalize(self):
+        self.append(self.additionalXML)
         self.append('</model>')
         self.append('</sdf>')


### PR DESCRIPTION
This adds an optional feature of adding arbitrary XML code (specified in another file) to the output.
In our use case it is needed to specify the sensors for simulation, as this is not possible directly in onshape.