### PR TITLE
[DEV] Use model path in sdf meshes

### DIFF
--- a/onshape_to_robot/config.py
+++ b/onshape_to_robot/config.py
@@ -3,6 +3,7 @@ import sys
 import os
 import commentjson as json
 from colorama import Fore, Back, Style
+from pathlib import Path
 
 config = {}
 
@@ -40,7 +41,7 @@ if not os.path.exists(configFile):
     print(Fore.RED+"ERROR: The file "+configFile+" can't be found"+Style.RESET_ALL)
     exit()
 config = json.load(open(configFile))
-
+config['robotFolder'] = Path(robot).name
 config['documentId'] = configGet('documentId')
 config['versionId'] = configGet('versionId', '')
 config['workspaceId'] = configGet('workspaceId', '')

--- a/onshape_to_robot/onshape_to_robot.py
+++ b/onshape_to_robot/onshape_to_robot.py
@@ -36,6 +36,7 @@ robot.robotName = config['robotName']
 robot.additionalXML = config['additionalXML']
 robot.useFixedLinks = config['useFixedLinks']
 robot.meshDir = config['outputDirectory']
+robot.robotFolder = config['robotFolder']
 
 
 def partIsIgnore(name):

--- a/onshape_to_robot/robot_description.py
+++ b/onshape_to_robot/robot_description.py
@@ -4,7 +4,6 @@ import math
 import uuid
 from . import stl_combine
 
-
 def rotationMatrixToEulerAngles(R):
     sy = math.sqrt(R[0, 0] * R[0, 0] + R[1, 0] * R[1, 0])
 
@@ -62,6 +61,7 @@ class RobotDescription(object):
         self.addDummyBaseLink = False
         self.robotName = name
         self.meshDir = None
+        self.robotFolder = ''
 
     def shouldMergeSTLs(self, node):
         return self.mergeSTLs == 'all' or self.mergeSTLs == node
@@ -437,7 +437,7 @@ class RobotSDF(RobotDescription):
         self.append('<'+node+' name="'+name+'_visual">')
         self.append(pose(matrix))
         self.append('<geometry>')
-        self.append('<mesh><uri>file://'+stl+'</uri></mesh>')
+        self.append(f'<mesh><uri>model://{self.robotFolder}/{stl}</uri></mesh>')
         self.append('</geometry>')
         if node == 'visual':
             self.append(self.material(color))


### PR DESCRIPTION
fix https://github.com/Rhoban/onshape-to-robot/issues/15

The name of the folder containing the `config.json` file should be the same as the robot name. Maybe we  can do better, but I got gazebo and ros to find the model and meshes with this.
