### PR TITLE
Update usage info for onshape_to_robot

### DIFF
--- a/onshape_to_robot/config.py
+++ b/onshape_to_robot/config.py
@@ -9,7 +9,7 @@ config = {}
 # Loading configuration & parameters
 if len(sys.argv) <= 1:
     print(Fore.RED +
-          'ERROR: usage: onshape-to-robot.py [robot_directory]' + Style.RESET_ALL)
+          'ERROR: usage: onshape-to-robot {robot_directory}' + Style.RESET_ALL)
     print("Read documentation at https://onshape-to-robot.readthedocs.io/")
     exit("")
 robot = sys.argv[1]


### PR DESCRIPTION
Update usage message to correct executable name and add braces to
reflect that robot_directory argument is required. Typically this would
be shown without any surrounding punctuation in the man pages, but I
used braces to keep consistent with other usage messages in this repo.