### PR TITLE
Use context managers for handling files

### DIFF
--- a/onshape_to_robot/config.py
+++ b/onshape_to_robot/config.py
@@ -39,7 +39,8 @@ configFile = robot+'/config.json'
 if not os.path.exists(configFile):
     print(Fore.RED+"ERROR: The file "+configFile+" can't be found"+Style.RESET_ALL)
     exit()
-config = json.load(open(configFile))
+with open(configFile, "r", encoding="utf8") as stream:
+    config = json.load(stream)
 
 config['documentId'] = configGet('documentId')
 config['versionId'] = configGet('versionId', '')
@@ -99,8 +100,8 @@ else:
 if additionalFileName == '':
     config['additionalXML'] = ''
 else:
-    with open(robot + additionalFileName, 'r') as additionalXMLFile:
-        config['additionalXML'] = additionalXMLFile.read()
+    with open(robot + additionalFileName, "r", encoding="utf-8") as stream:
+        config['additionalXML'] = stream.read()
 
 
 # Creating dynamics override array

--- a/onshape_to_robot/csg.py
+++ b/onshape_to_robot/csg.py
@@ -116,9 +116,8 @@ def parse_csg(data, dilatation):
 def process(filename, dilatation):
     tmp_data = os.getcwd()+'/_tmp_data.csg'
     os.system('openscad '+filename+' -o '+tmp_data)
-    f = open(tmp_data)
-    data = f.read()
-    f.close()
+    with open(tmp_data, "r", encoding="utf-8") as stream:
+        data = stream.read()
     os.system('rm '+tmp_data)
 
     return parse_csg(data, dilatation)

--- a/onshape_to_robot/edit_shape.py
+++ b/onshape_to_robot/edit_shape.py
@@ -15,8 +15,7 @@ else:
         scad += "// cube([10, 10, 10], center=true);\n"
         scad += "// cylinder(r=10, h=10, center=true);\n"
         scad += "// sphere(10);\n"
-        f = open(fileName, 'w')
-        f.write(scad)
-        f.close()
+        with open(fileName, "w", encoding="utf-8") as stream:
+            stream.write(scad)
     directory = os.path.dirname(fileName)
     os.system('cd '+directory+'; openscad '+os.path.basename(fileName))

--- a/onshape_to_robot/onshape_api/client.py
+++ b/onshape_to_robot/onshape_api/client.py
@@ -121,14 +121,12 @@ class Client():
             os.mkdir(dirName)
         fileName = dirName+'/'+fileName
         if os.path.exists(fileName):
-            f = open(fileName, 'rb')
-            result = f.read()
-            f.close()
+            with open(fileName, "rb", encoding="utf-8") as stream:
+                result = stream.read()
         else:
             result = callback().content
-            f = open(fileName, 'wb')
-            f.write(result)
-            f.close()
+            with open(fileName, 'wb') as stream:
+                stream.write(result)
         if isString and type(result) == bytes:
             result = result.decode('utf-8')
         return result
@@ -237,7 +235,8 @@ class Client():
         mimetype = mimetypes.guess_type(filepath)[0]
         encoded_filename = os.path.basename(filepath)
         file_content_length = str(os.path.getsize(filepath))
-        blob = open(filepath)
+        with open(filepath, "r", encoding="utf-8") as stream:
+            blob = stream.read()
 
         req_headers = {
             'Content-Type': 'multipart/form-data; boundary="%s"' % boundary_key
@@ -248,7 +247,7 @@ class Client():
         payload += '--' + boundary_key + '\r\nContent-Disposition: form-data; name="fileContentLength"\r\n\r\n' + file_content_length + '\r\n'
         payload += '--' + boundary_key + '\r\nContent-Disposition: form-data; name="file"; filename="' + encoded_filename + '"\r\n'
         payload += 'Content-Type: ' + mimetype + '\r\n\r\n'
-        payload += blob.read()
+        payload += blob
         payload += '\r\n--' + boundary_key + '--'
 
         return self._api.request('post', '/api/blobelements/d/' + did + '/w/' + wid, headers=req_headers, body=payload)

--- a/onshape_to_robot/onshape_api/onshape.py
+++ b/onshape_to_robot/onshape_api/onshape.py
@@ -62,33 +62,35 @@ class Onshape():
 
         self._logging = logging
 
-        with open(creds) as f:
+        with open(creds, "r", encoding="utf-8") as stream:
             try:
-                config = json.load(f)
-                self._url = config["onshape_api"]
-                self._access_key = config['onshape_access_key'].encode('utf-8')
-                self._secret_key = config['onshape_secret_key'].encode('utf-8')
-            except TypeError:
-                raise ValueError('%s is not valid json' % creds)
-            except KeyError:
-                self._url = os.getenv('ONSHAPE_API')
-                self._access_key = os.getenv('ONSHAPE_ACCESS_KEY')
-                self._secret_key = os.getenv('ONSHAPE_SECRET_KEY')
+                config = json.load(stream)
+            except TypeError as ex:
+                raise ValueError('%s is not valid json' % creds) from ex
 
-                if self._url is None or self._access_key is None or self._secret_key is None:
-                    print(Fore.RED + 'ERROR: No OnShape API access key are set' + Style.RESET_ALL)
-                    print()
-                    print(Fore.BLUE + 'TIP: Connect to https://dev-portal.onshape.com/keys, and edit your .bashrc file:' + Style.RESET_ALL)
-                    print(Fore.BLUE + 'export ONSHAPE_API=https://cad.onshape.com' + Style.RESET_ALL)
-                    print(Fore.BLUE + 'export ONSHAPE_ACCESS_KEY=Your_Access_Key' + Style.RESET_ALL)
-                    print(Fore.BLUE + 'export ONSHAPE_SECRET_KEY=Your_Secret_Key' + Style.RESET_ALL)
-                    exit(1)
+        try:
+            self._url = config["onshape_api"]
+            self._access_key = config['onshape_access_key'].encode('utf-8')
+            self._secret_key = config['onshape_secret_key'].encode('utf-8')
+        except KeyError:
+            self._url = os.getenv('ONSHAPE_API')
+            self._access_key = os.getenv('ONSHAPE_ACCESS_KEY')
+            self._secret_key = os.getenv('ONSHAPE_SECRET_KEY')
 
-                self._access_key = self._access_key.encode('utf-8')
-                self._secret_key = self._secret_key.encode('utf-8')
+            if self._url is None or self._access_key is None or self._secret_key is None:
+                print(Fore.RED + 'ERROR: No OnShape API access key are set' + Style.RESET_ALL)
+                print()
+                print(Fore.BLUE + 'TIP: Connect to https://dev-portal.onshape.com/keys, and edit your .bashrc file:' + Style.RESET_ALL)
+                print(Fore.BLUE + 'export ONSHAPE_API=https://cad.onshape.com' + Style.RESET_ALL)
+                print(Fore.BLUE + 'export ONSHAPE_ACCESS_KEY=Your_Access_Key' + Style.RESET_ALL)
+                print(Fore.BLUE + 'export ONSHAPE_SECRET_KEY=Your_Secret_Key' + Style.RESET_ALL)
+                exit(1)
 
-                if self._url is None or self._access_key is None or self._secret_key is None:
-                    exit('No key in config.json, and environment variables not set')
+            self._access_key = self._access_key.encode('utf-8')
+            self._secret_key = self._secret_key.encode('utf-8')
+
+            if self._url is None or self._access_key is None or self._secret_key is None:
+                exit('No key in config.json, and environment variables not set')
 
         if self._logging:
             utils.log('onshape instance created: url = %s, access key = %s' % (self._url, self._access_key))

--- a/onshape_to_robot/onshape_to_robot.py
+++ b/onshape_to_robot/onshape_to_robot.py
@@ -86,14 +86,12 @@ def addPart(occurrence, matrix):
             shortend_configuration = part['configuration']
         stl = client.part_studio_stl_m(part['documentId'], part['documentMicroversion'], part['elementId'],
                                        part['partId'], shortend_configuration)
-        f = open(config['outputDirectory']+'/'+stlFile, 'wb')
-        f.write(stl)
-        f.close()
+        with open(config['outputDirectory']+'/'+stlFile, 'wb', encoding="utf-8") as stream:
+            stream.write(stl)
 
         stlMetadata = prefix.replace('/', '_')+'.part'
-        f = open(config['outputDirectory']+'/'+stlMetadata, 'wb')
-        f.write(json.dumps(part).encode('UTF-8'))
-        f.close()
+        with open(config['outputDirectory']+'/'+stlMetadata, 'wb', encoding="utf-8") as stream:
+            stream.write(json.dumps(part).encode('UTF-8'))
 
         stlFile = config['outputDirectory']+'/'+stlFile
 
@@ -242,9 +240,8 @@ robot.finalize()
 
 print("\n" + Style.BRIGHT + "* Writing " +
       robot.ext.upper()+" file" + Style.RESET_ALL)
-f = open(config['outputDirectory']+'/robot.'+robot.ext, 'w')
-f.write(robot.xml)
-f.close()
+with open(config['outputDirectory']+'/robot.'+robot.ext, 'w', encoding="utf-8") as stream:
+    stream.write(robot.xml)
 
 if len(config['postImportCommands']):
     print("\n" + Style.BRIGHT + "* Executing post-import commands" + Style.RESET_ALL)

--- a/onshape_to_robot/pure_sketch.py
+++ b/onshape_to_robot/pure_sketch.py
@@ -24,8 +24,8 @@ else:
     parts[-1] = 'scad'
     scadFileName = '.'.join(parts)
 
-    f = open(partFileName, 'r')
-    part = json.load(f)
+    with open(partFileName, 'r', encoding="utf-8") as stream:
+        part = json.load(stream)
     partid = part['partId']
     result = client.get_sketches(part['documentId'], part['documentMicroversion'], part['elementId'], part['configuration'])
 
@@ -108,14 +108,10 @@ else:
             scad += "}\n"
             scad += "}\n"
 
-        f = open(scadFileName, 'w')
-        f.write(scad)
-        f.close()
+        with open(scadFileName, 'w', encoding="utf-8") as stream:
+            stream.write(scad)
 
         directory = os.path.dirname(fileName)
         os.system('cd '+directory+'; openscad '+os.path.basename(scadFileName))
     else:
         print(Fore.RED + "ERROR: Can't find pure shape sketch in this part" + Style.RESET_ALL)
-
-
-    

--- a/onshape_to_robot/stl_combine.py
+++ b/onshape_to_robot/stl_combine.py
@@ -61,8 +61,8 @@ filter_script_mlx = """<!DOCTYPE FilterScript>
 
 
 def create_tmp_filter_file(filename='filter_file_tmp.mlx', reduction=0.9):
-    with open('/tmp/' + filename, 'w') as f:
-        f.write(filter_script_mlx.replace('%reduction%', str(reduction)))
+    with open('/tmp/' + filename, 'w', encoding="utf-8") as stream:
+        stream.write(filter_script_mlx.replace('%reduction%', str(reduction)))
     return '/tmp/' + filename
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
-with open("README-pypi.md", "r") as fh:
-    long_description = fh.read()
+with open("README-pypi.md", "r", encoding="utf-8") as stream:
+    long_description = stream.read()
 
 setuptools.setup(
     name="onshape-to-robot",


### PR DESCRIPTION
- Use the standard `with` statement for opening files, which creates a
  context manager to ensure files are closed properly.
- Use `stream` variable name when opening files for consistency.
- Specifiy encoding explicitly as "utf-8" when opening non-binary files.