### PR TITLE
Fix entrypoint scripts and cache path on some environments

### DIFF
--- a/onshape_to_robot/__init__.py
+++ b/onshape_to_robot/__init__.py
@@ -1,3 +1,6 @@
-
-__all__ = ["onshape_to_robot"]
-
+"""Export models from OnShape to other robotics formats."""
+from . import bullet  # noqa: F401
+from . import clear_cache  # noqa: F401
+from . import edit_shape  # noqa: F401
+from . import onshape_to_robot  # noqa: F401
+from . import pure_sketch  # noqa: F401

--- a/onshape_to_robot/bullet.py
+++ b/onshape_to_robot/bullet.py
@@ -6,55 +6,61 @@ import argparse
 import pybullet as p
 from .simulation import Simulation
 
-parser = argparse.ArgumentParser(prog="onshape-to-robot-bullet")
-parser.add_argument('-f', '--fixed', action='store_true')
-parser.add_argument('-x', '--x', type=float, default=0)
-parser.add_argument('-y', '--y', type=float, default=0)
-parser.add_argument('-z', '--z', type=float, default=0)
-parser.add_argument('directory')
-args = parser.parse_args()
 
-robotPath = args.directory
-if not robotPath.endswith('.urdf'):
-    robotPath += '/robot.urdf'
+def main():
+    parser = argparse.ArgumentParser(prog="onshape-to-robot-bullet")
+    parser.add_argument('-f', '--fixed', action='store_true')
+    parser.add_argument('-x', '--x', type=float, default=0)
+    parser.add_argument('-y', '--y', type=float, default=0)
+    parser.add_argument('-z', '--z', type=float, default=0)
+    parser.add_argument('directory')
+    args = parser.parse_args()
 
-sim = Simulation(robotPath, gui=True, panels=True, fixed=args.fixed)
-pos, rpy = sim.getRobotPose()
-_, orn = p.getBasePositionAndOrientation(sim.robot)
-sim.setRobotPose([pos[0] + args.x, pos[1] + args.y, pos[2] + args.z], orn)
+    robotPath = args.directory
+    if not robotPath.endswith('.urdf'):
+        robotPath += '/robot.urdf'
 
-controls = {}
-for name in sim.getJoints():
-    if name.endswith('_speed'):
-        controls[name] = p.addUserDebugParameter(
-            name, -math.pi*3, math.pi*3, 0)
-    else:
-        infos = sim.getJointsInfos(name)
-        low = -math.pi
-        high = math.pi
-        if 'lowerLimit' in infos:
-            low = infos['lowerLimit']
-        if 'upperLimit' in infos:
-            high = infos['upperLimit']
-        controls[name] = p.addUserDebugParameter(name, low, high, 0)
+    sim = Simulation(robotPath, gui=True, panels=True, fixed=args.fixed)
+    pos, rpy = sim.getRobotPose()
+    _, orn = p.getBasePositionAndOrientation(sim.robot)
+    sim.setRobotPose([pos[0] + args.x, pos[1] + args.y, pos[2] + args.z], orn)
 
-lastPrint = 0
-while True:
-    targets = {}
-    for name in controls.keys():
-        targets[name] = p.readUserDebugParameter(controls[name])
-    sim.setJoints(targets)
+    controls = {}
+    for name in sim.getJoints():
+        if name.endswith('_speed'):
+            controls[name] = p.addUserDebugParameter(
+                name, -math.pi*3, math.pi*3, 0)
+        else:
+            infos = sim.getJointsInfos(name)
+            low = -math.pi
+            high = math.pi
+            if 'lowerLimit' in infos:
+                low = infos['lowerLimit']
+            if 'upperLimit' in infos:
+                high = infos['upperLimit']
+            controls[name] = p.addUserDebugParameter(name, low, high, 0)
 
-    if time.time() - lastPrint > 0.05:
-        lastPrint = time.time()
-        os.system("clear")
-        frames = sim.getFrames()
-        for frame in frames:
-            print(frame)
-            print("- x=%f\ty=%f\tz=%f" % frames[frame][0])
-            print("- r=%f\tp=%f\ty=%f" % frames[frame][1])
-            print("")
-            print("Center of mass:")
-            print(sim.getCenterOfMassPosition())
+    lastPrint = 0
+    while True:
+        targets = {}
+        for name in controls.keys():
+            targets[name] = p.readUserDebugParameter(controls[name])
+        sim.setJoints(targets)
 
-    sim.tick()
+        if time.time() - lastPrint > 0.05:
+            lastPrint = time.time()
+            os.system("clear")
+            frames = sim.getFrames()
+            for frame in frames:
+                print(frame)
+                print("- x=%f\ty=%f\tz=%f" % frames[frame][0])
+                print("- r=%f\tp=%f\ty=%f" % frames[frame][1])
+                print("")
+                print("Center of mass:")
+                print(sim.getCenterOfMassPosition())
+
+        sim.tick()
+
+
+if __name__ == "__main__":
+    main()

--- a/onshape_to_robot/clear_cache.py
+++ b/onshape_to_robot/clear_cache.py
@@ -1,17 +1,15 @@
 """Clear the onshape-to-robot cache."""
-import os
+import shutil
 
-from . import onshape_api as api
-
-# Directory used for cache.
-CACHE_DIR = os.path.join(os.path.dirname(api.__file__), "cache")
+from .onshape_api.client import Client
 
 
-def clear_cache():
+def main():
     """Clear the onshape-to-robot cache."""
-    print("Cleaning cache directory ({})".format(CACHE_DIR))
-    os.system("rm -rf {}/*".format(CACHE_DIR))
+    cache_dir = Client.get_cache_path()
+    print("Removing cache directory: {}".format(cache_dir))
+    shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":
-    clear_cache()
+    main()

--- a/onshape_to_robot/config.py
+++ b/onshape_to_robot/config.py
@@ -39,7 +39,8 @@ configFile = robot+'/config.json'
 if not os.path.exists(configFile):
     print(Fore.RED+"ERROR: The file "+configFile+" can't be found"+Style.RESET_ALL)
     exit()
-config = json.load(open(configFile))
+with open(configFile, "r", encoding="utf8") as stream:
+    config = json.load(stream)
 
 config['documentId'] = configGet('documentId')
 config['versionId'] = configGet('versionId', '')
@@ -99,8 +100,8 @@ else:
 if additionalFileName == '':
     config['additionalXML'] = ''
 else:
-    with open(robot + additionalFileName, 'r') as additionalXMLFile:
-        config['additionalXML'] = additionalXMLFile.read()
+    with open(robot + additionalFileName, "r", encoding="utf-8") as stream:
+        config['additionalXML'] = stream.read()
 
 
 # Creating dynamics override array

--- a/onshape_to_robot/csg.py
+++ b/onshape_to_robot/csg.py
@@ -116,9 +116,8 @@ def parse_csg(data, dilatation):
 def process(filename, dilatation):
     tmp_data = os.getcwd()+'/_tmp_data.csg'
     os.system('openscad '+filename+' -o '+tmp_data)
-    f = open(tmp_data)
-    data = f.read()
-    f.close()
+    with open(tmp_data, "r", encoding="utf-8") as stream:
+        data = stream.read()
     os.system('rm '+tmp_data)
 
     return parse_csg(data, dilatation)

--- a/onshape_to_robot/edit_shape.py
+++ b/onshape_to_robot/edit_shape.py
@@ -15,8 +15,7 @@ else:
         scad += "// cube([10, 10, 10], center=true);\n"
         scad += "// cylinder(r=10, h=10, center=true);\n"
         scad += "// sphere(10);\n"
-        f = open(fileName, 'w')
-        f.write(scad)
-        f.close()
+        with open(fileName, "w", encoding="utf-8") as stream:
+            stream.write(scad)
     directory = os.path.dirname(fileName)
     os.system('cd '+directory+'; openscad '+os.path.basename(fileName))

--- a/onshape_to_robot/edit_shape.py
+++ b/onshape_to_robot/edit_shape.py
@@ -1,21 +1,27 @@
-import sys
 import os
+import sys
 
-if len(sys.argv) < 2:
-    print('Usage: onshape-to-robot-edit-shape {STL file}')
-else:
-    fileName = sys.argv[1]
-    parts = fileName.split('.')
-    parts[-1] = 'scad'
-    fileName = '.'.join(parts)
-    if not os.path.exists(fileName):
-        scad = "% scale(1000) import(\""+os.path.basename(sys.argv[1])+"\");\n"
-        scad += "\n"
-        scad += "// Append pure shapes (cube, cylinder and sphere), e.g:\n"
-        scad += "// cube([10, 10, 10], center=true);\n"
-        scad += "// cylinder(r=10, h=10, center=true);\n"
-        scad += "// sphere(10);\n"
-        with open(fileName, "w", encoding="utf-8") as stream:
-            stream.write(scad)
-    directory = os.path.dirname(fileName)
-    os.system('cd '+directory+'; openscad '+os.path.basename(fileName))
+
+def main():
+    if len(sys.argv) < 2:
+        print('Usage: onshape-to-robot-edit-shape {STL file}')
+    else:
+        fileName = sys.argv[1]
+        parts = fileName.split('.')
+        parts[-1] = 'scad'
+        fileName = '.'.join(parts)
+        if not os.path.exists(fileName):
+            scad = "% scale(1000) import(\""+os.path.basename(sys.argv[1])+"\");\n"
+            scad += "\n"
+            scad += "// Append pure shapes (cube, cylinder and sphere), e.g:\n"
+            scad += "// cube([10, 10, 10], center=true);\n"
+            scad += "// cylinder(r=10, h=10, center=true);\n"
+            scad += "// sphere(10);\n"
+            with open(fileName, "w", encoding="utf-8") as stream:
+                stream.write(scad)
+        directory = os.path.dirname(fileName)
+        os.system('cd '+directory+'; openscad '+os.path.basename(fileName))
+
+
+if __name__ == '__main__':
+    main()

--- a/onshape_to_robot/onshape_api/client.py
+++ b/onshape_to_robot/onshape_api/client.py
@@ -13,6 +13,7 @@ import string
 import os
 import json
 import hashlib
+from pathlib import Path
 
 def double_escape_slash(s):
     return s.replace('/', '%252f')
@@ -47,6 +48,14 @@ class Client():
         self._stack = stack
         self._api = Onshape(stack=stack, logging=logging, creds=creds)
         self.useCollisionsConfigurations = True
+
+    @staticmethod
+    def get_cache_path() -> Path:
+        """Return the path to the user cache."""
+        path = Path.home() / ".cache" / "onshape-to-robot"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
 
     def new_document(self, name='Test Document', owner_type=0, public=False):
         '''
@@ -116,12 +125,10 @@ class Client():
         if type(key) == tuple:
             key = '_'.join(list(key))
         fileName = method+'__'+key
-        dirName = os.path.dirname(os.path.abspath(__file__))+'/cache'
-        if not os.path.exists(dirName):
-            os.mkdir(dirName)
-        fileName = dirName+'/'+fileName
+        dirName = self.get_cache_path()
+        fileName = dirName / fileName
         if os.path.exists(fileName):
-            with open(fileName, "rb", encoding="utf-8") as stream:
+            with open(fileName, "rb") as stream:
                 result = stream.read()
         else:
             result = callback().content

--- a/onshape_to_robot/onshape_api/client.py
+++ b/onshape_to_robot/onshape_api/client.py
@@ -121,14 +121,12 @@ class Client():
             os.mkdir(dirName)
         fileName = dirName+'/'+fileName
         if os.path.exists(fileName):
-            f = open(fileName, 'rb')
-            result = f.read()
-            f.close()
+            with open(fileName, "rb", encoding="utf-8") as stream:
+                result = stream.read()
         else:
             result = callback().content
-            f = open(fileName, 'wb')
-            f.write(result)
-            f.close()
+            with open(fileName, 'wb') as stream:
+                stream.write(result)
         if isString and type(result) == bytes:
             result = result.decode('utf-8')
         return result
@@ -237,7 +235,8 @@ class Client():
         mimetype = mimetypes.guess_type(filepath)[0]
         encoded_filename = os.path.basename(filepath)
         file_content_length = str(os.path.getsize(filepath))
-        blob = open(filepath)
+        with open(filepath, "r", encoding="utf-8") as stream:
+            blob = stream.read()
 
         req_headers = {
             'Content-Type': 'multipart/form-data; boundary="%s"' % boundary_key
@@ -248,7 +247,7 @@ class Client():
         payload += '--' + boundary_key + '\r\nContent-Disposition: form-data; name="fileContentLength"\r\n\r\n' + file_content_length + '\r\n'
         payload += '--' + boundary_key + '\r\nContent-Disposition: form-data; name="file"; filename="' + encoded_filename + '"\r\n'
         payload += 'Content-Type: ' + mimetype + '\r\n\r\n'
-        payload += blob.read()
+        payload += blob
         payload += '\r\n--' + boundary_key + '--'
 
         return self._api.request('post', '/api/blobelements/d/' + did + '/w/' + wid, headers=req_headers, body=payload)

--- a/onshape_to_robot/onshape_api/onshape.py
+++ b/onshape_to_robot/onshape_api/onshape.py
@@ -62,33 +62,35 @@ class Onshape():
 
         self._logging = logging
 
-        with open(creds) as f:
+        with open(creds, "r", encoding="utf-8") as stream:
             try:
-                config = json.load(f)
-                self._url = config["onshape_api"]
-                self._access_key = config['onshape_access_key'].encode('utf-8')
-                self._secret_key = config['onshape_secret_key'].encode('utf-8')
-            except TypeError:
-                raise ValueError('%s is not valid json' % creds)
-            except KeyError:
-                self._url = os.getenv('ONSHAPE_API')
-                self._access_key = os.getenv('ONSHAPE_ACCESS_KEY')
-                self._secret_key = os.getenv('ONSHAPE_SECRET_KEY')
+                config = json.load(stream)
+            except TypeError as ex:
+                raise ValueError('%s is not valid json' % creds) from ex
 
-                if self._url is None or self._access_key is None or self._secret_key is None:
-                    print(Fore.RED + 'ERROR: No OnShape API access key are set' + Style.RESET_ALL)
-                    print()
-                    print(Fore.BLUE + 'TIP: Connect to https://dev-portal.onshape.com/keys, and edit your .bashrc file:' + Style.RESET_ALL)
-                    print(Fore.BLUE + 'export ONSHAPE_API=https://cad.onshape.com' + Style.RESET_ALL)
-                    print(Fore.BLUE + 'export ONSHAPE_ACCESS_KEY=Your_Access_Key' + Style.RESET_ALL)
-                    print(Fore.BLUE + 'export ONSHAPE_SECRET_KEY=Your_Secret_Key' + Style.RESET_ALL)
-                    exit(1)
+        try:
+            self._url = config["onshape_api"]
+            self._access_key = config['onshape_access_key'].encode('utf-8')
+            self._secret_key = config['onshape_secret_key'].encode('utf-8')
+        except KeyError:
+            self._url = os.getenv('ONSHAPE_API')
+            self._access_key = os.getenv('ONSHAPE_ACCESS_KEY')
+            self._secret_key = os.getenv('ONSHAPE_SECRET_KEY')
 
-                self._access_key = self._access_key.encode('utf-8')
-                self._secret_key = self._secret_key.encode('utf-8')
+            if self._url is None or self._access_key is None or self._secret_key is None:
+                print(Fore.RED + 'ERROR: No OnShape API access key are set' + Style.RESET_ALL)
+                print()
+                print(Fore.BLUE + 'TIP: Connect to https://dev-portal.onshape.com/keys, and edit your .bashrc file:' + Style.RESET_ALL)
+                print(Fore.BLUE + 'export ONSHAPE_API=https://cad.onshape.com' + Style.RESET_ALL)
+                print(Fore.BLUE + 'export ONSHAPE_ACCESS_KEY=Your_Access_Key' + Style.RESET_ALL)
+                print(Fore.BLUE + 'export ONSHAPE_SECRET_KEY=Your_Secret_Key' + Style.RESET_ALL)
+                exit(1)
 
-                if self._url is None or self._access_key is None or self._secret_key is None:
-                    exit('No key in config.json, and environment variables not set')
+            self._access_key = self._access_key.encode('utf-8')
+            self._secret_key = self._secret_key.encode('utf-8')
+
+            if self._url is None or self._access_key is None or self._secret_key is None:
+                exit('No key in config.json, and environment variables not set')
 
         if self._logging:
             utils.log('onshape instance created: url = %s, access key = %s' % (self._url, self._access_key))

--- a/onshape_to_robot/onshape_to_robot.py
+++ b/onshape_to_robot/onshape_to_robot.py
@@ -9,242 +9,248 @@ import hashlib
 from . import csg
 from .robot_description import RobotURDF, RobotSDF
 
-# Loading configuration, collecting occurrences and building robot tree
-from .load_robot import \
-    config, client, tree, occurrences, getOccurrence, frames
-
-# Creating robot for output
-if config['outputFormat'] == 'urdf':
-    robot = RobotURDF(config['robotName'])
-elif config['outputFormat'] == 'sdf':
-    robot = RobotSDF(config['robotName'])
-else:
-    print(Fore.RED + 'ERROR: Unknown output format: ' +
-          config['outputFormat']+' (supported are urdf and sdf)' + Style.RESET_ALL)
-    exit()
-robot.drawCollisions = config['drawCollisions']
-robot.jointMaxEffort = config['jointMaxEffort']
-robot.mergeSTLs = config['mergeSTLs']
-robot.maxSTLSize = config['maxSTLSize']
-robot.simplifySTLs = config['simplifySTLs']
-robot.jointMaxVelocity = config['jointMaxVelocity']
-robot.noDynamics = config['noDynamics']
-robot.packageName = config['packageName']
-robot.addDummyBaseLink = config['addDummyBaseLink']
-robot.robotName = config['robotName']
-robot.additionalXML = config['additionalXML']
-robot.useFixedLinks = config['useFixedLinks']
-robot.meshDir = config['outputDirectory']
-
-
-def partIsIgnore(name):
-    global config
-
-    if config['whitelist'] is None:
-        return name in config['ignore']
-    else:
-        return name not in config['whitelist']
-
-# Adds a part to the current robot link
-
-
-def addPart(occurrence, matrix):
-    global config, occurrenceLinkNames
-    part = occurrence['instance']
-
-    if part['suppressed']:
-        return
-
-    if part['partId'] == '':
-        print(Fore.YELLOW + 'WARNING: Part '+part['name']+' has no partId'+Style.RESET_ALL)
-        return
-
-    # Importing STL file for this part
-    justPart, prefix = extractPartName(part['name'], part['configuration'])
-
-    extra = ''
-    if occurrence['instance']['configuration'] != 'default':
-        extra = Style.DIM + ' (configuration: ' + \
-            occurrence['instance']['configuration']+')'
-    symbol = '+'
-    if partIsIgnore(justPart):
-        symbol = '-'
-        extra += Style.DIM + ' / ignoring visual and collision'
-
-    print(Fore.GREEN + symbol+' Adding part ' +
-          occurrence['instance']['name']+extra + Style.RESET_ALL)
-
-    if partIsIgnore(justPart):
-        stlFile = None
-    else:
-        stlFile = prefix.replace('/', '_')+'.stl'
-        # shorten the configuration to a maximum number of chars to prevent errors. Necessary for standard parts like screws
-        if len(part['configuration']) > 40:
-            shortend_configuration = hashlib.md5(
-                part['configuration'].encode('utf-8')).hexdigest()
-        else:
-            shortend_configuration = part['configuration']
-        stl = client.part_studio_stl_m(part['documentId'], part['documentMicroversion'], part['elementId'],
-                                       part['partId'], shortend_configuration)
-        with open(config['outputDirectory']+'/'+stlFile, 'wb', encoding="utf-8") as stream:
-            stream.write(stl)
-
-        stlMetadata = prefix.replace('/', '_')+'.part'
-        with open(config['outputDirectory']+'/'+stlMetadata, 'wb', encoding="utf-8") as stream:
-            stream.write(json.dumps(part).encode('UTF-8'))
-
-        stlFile = config['outputDirectory']+'/'+stlFile
-
-    # Import the SCAD files pure shapes
-    shapes = None
-    if config['useScads']:
-        scadFile = prefix+'.scad'
-        if os.path.exists(config['outputDirectory']+'/'+scadFile):
-            shapes = csg.process(
-                config['outputDirectory']+'/'+scadFile, config['pureShapeDilatation'])
-
-    # Obtain metadatas about part to retrieve color
-    if config['color'] is not None:
-        color = config['color']
-    else:
-        metadata = client.part_get_metadata(
-            part['documentId'], part['documentMicroversion'], part['elementId'], part['partId'], part['configuration'])
-        if 'appearance' in metadata:
-            colors = metadata['appearance']['color']
-            color = np.array(
-                [colors['red'], colors['green'], colors['blue']])/255.0
-        else:
-            color = [0.5, 0.5, 0.5]
-
-    # Obtain mass properties about that part
-    if config['noDynamics']:
-        mass = 0
-        com = [0]*3
-        inertia = [0]*12
-    else:
-        if prefix in config['dynamicsOverride']:
-            entry = config['dynamicsOverride'][prefix]
-            mass = entry['mass']
-            com = entry['com']
-            inertia = entry['inertia']
-        else:
-            massProperties = client.part_mass_properties(
-                part['documentId'], part['documentMicroversion'], part['elementId'], part['partId'], part['configuration'])
-
-            if part['partId'] not in massProperties['bodies']:
-                print(Fore.YELLOW + 'WARNING: part ' +
-                      part['name']+' has no dynamics (maybe it is a surface)' + Style.RESET_ALL)
-                return
-            massProperties = massProperties['bodies'][part['partId']]
-            mass = massProperties['mass'][0]
-            com = massProperties['centroid']
-            inertia = massProperties['inertia']
-
-            if abs(mass) < 1e-9:
-                print(Fore.YELLOW + 'WARNING: part ' +
-                      part['name']+' has no mass, maybe you should assign a material to it ?' + Style.RESET_ALL)
-
-    pose = occurrence['transform']
-    if robot.relative:
-        pose = np.linalg.inv(matrix)*pose
-
-    robot.addPart(pose, stlFile, mass, com, inertia, color, shapes, prefix)
-
 
 partNames = {}
 
-
-def extractPartName(name, configuration):
-    parts = name.split(' ')
-    del parts[-1]
-    basePartName = '_'.join(parts).lower()
-
-    # only add configuration to name if its not default and not a very long configuration (which happens for library parts like screws)
-    if configuration != 'default' and len(configuration) < 40:
-        parts += ['_' + configuration.replace('=', '_').replace(' ', '_')]
-
-    return basePartName, '_'.join(parts).lower()
+def main():
+    # Loading configuration, collecting occurrences and building robot tree
+    from .load_robot import \
+        config, client, tree, occurrences, getOccurrence, frames
 
 
-def processPartName(name, configuration, overrideName=None):
-    if overrideName is None:
-        global partNames
-        _, name = extractPartName(name, configuration)
-
-        if name in partNames:
-            partNames[name] += 1
-        else:
-            partNames[name] = 1
-
-        if partNames[name] == 1:
-            return name
-        else:
-            return name+'_'+str(partNames[name])
+    # Creating robot for output
+    if config['outputFormat'] == 'urdf':
+        robot = RobotURDF(config['robotName'])
+    elif config['outputFormat'] == 'sdf':
+        robot = RobotSDF(config['robotName'])
     else:
-        return overrideName
+        print(Fore.RED + 'ERROR: Unknown output format: ' +
+            config['outputFormat']+' (supported are urdf and sdf)' + Style.RESET_ALL)
+        exit()
+    robot.drawCollisions = config['drawCollisions']
+    robot.jointMaxEffort = config['jointMaxEffort']
+    robot.mergeSTLs = config['mergeSTLs']
+    robot.maxSTLSize = config['maxSTLSize']
+    robot.simplifySTLs = config['simplifySTLs']
+    robot.jointMaxVelocity = config['jointMaxVelocity']
+    robot.noDynamics = config['noDynamics']
+    robot.packageName = config['packageName']
+    robot.addDummyBaseLink = config['addDummyBaseLink']
+    robot.robotName = config['robotName']
+    robot.additionalXML = config['additionalXML']
+    robot.useFixedLinks = config['useFixedLinks']
+    robot.meshDir = config['outputDirectory']
 
 
-def buildRobot(tree, matrix):
-    occurrence = getOccurrence([tree['id']])
-    instance = occurrence['instance']
-    print(Fore.BLUE + Style.BRIGHT +
-          '* Adding top-level instance ['+instance['name']+']' + Style.RESET_ALL)
-
-    # Build a part name that is unique but still informative
-    link = processPartName(
-        instance['name'], instance['configuration'], occurrence['linkName'])
-
-    # Create the link, collecting all children in the tree assigned to this top-level part
-    robot.startLink(link, matrix)
-    for occurrence in occurrences.values():
-        if occurrence['assignation'] == tree['id'] and occurrence['instance']['type'] == 'Part':
-            addPart(occurrence, matrix)
-    robot.endLink()
-
-    # Adding the frames (linkage is relative to parent)
-    if tree['id'] in frames:
-        for name, part in frames[tree['id']]:
-            frame = getOccurrence(part)['transform']
-            if robot.relative:
-                frame = np.linalg.inv(matrix)*frame
-            robot.addFrame(name, frame)
-
-    # Following the children in the tree, calling this function recursively
-    k = 0
-    for child in tree['children']:
-        worldAxisFrame = child['axis_frame']
-        zAxis = child['z_axis']
-        jointType = child['jointType']
-        jointLimits = child['jointLimits']
-
-        if robot.relative:
-            axisFrame = np.linalg.inv(matrix)*worldAxisFrame
-            childMatrix = worldAxisFrame
+    def partIsIgnore(name):
+        if config['whitelist'] is None:
+            return name in config['ignore']
         else:
-            # In SDF format, everything is expressed in the world frame, in this case
-            # childMatrix will be always identity
-            axisFrame = worldAxisFrame
-            childMatrix = matrix
+            return name not in config['whitelist']
 
-        subLink = buildRobot(child, childMatrix)
-        robot.addJoint(jointType, link, subLink, axisFrame,
-                       child['dof_name'], jointLimits, zAxis)
-
-    return link
+    # Adds a part to the current robot link
 
 
-# Start building the robot
-buildRobot(tree, np.matrix(np.identity(4)))
-robot.finalize()
-# print(tree)
+    def addPart(occurrence, matrix):
+        part = occurrence['instance']
 
-print("\n" + Style.BRIGHT + "* Writing " +
-      robot.ext.upper()+" file" + Style.RESET_ALL)
-with open(config['outputDirectory']+'/robot.'+robot.ext, 'w', encoding="utf-8") as stream:
-    stream.write(robot.xml)
+        if part['suppressed']:
+            return
 
-if len(config['postImportCommands']):
-    print("\n" + Style.BRIGHT + "* Executing post-import commands" + Style.RESET_ALL)
-    for command in config['postImportCommands']:
-        print("* "+command)
-        os.system(command)
+        if part['partId'] == '':
+            print(Fore.YELLOW + 'WARNING: Part '+part['name']+' has no partId'+Style.RESET_ALL)
+            return
+
+        # Importing STL file for this part
+        justPart, prefix = extractPartName(part['name'], part['configuration'])
+
+        extra = ''
+        if occurrence['instance']['configuration'] != 'default':
+            extra = Style.DIM + ' (configuration: ' + \
+                occurrence['instance']['configuration']+')'
+        symbol = '+'
+        if partIsIgnore(justPart):
+            symbol = '-'
+            extra += Style.DIM + ' / ignoring visual and collision'
+
+        print(Fore.GREEN + symbol+' Adding part ' +
+            occurrence['instance']['name']+extra + Style.RESET_ALL)
+
+        if partIsIgnore(justPart):
+            stlFile = None
+        else:
+            stlFile = prefix.replace('/', '_')+'.stl'
+            # shorten the configuration to a maximum number of chars to prevent errors. Necessary for standard parts like screws
+            if len(part['configuration']) > 40:
+                shortend_configuration = hashlib.md5(
+                    part['configuration'].encode('utf-8')).hexdigest()
+            else:
+                shortend_configuration = part['configuration']
+            stl = client.part_studio_stl_m(part['documentId'], part['documentMicroversion'], part['elementId'],
+                                        part['partId'], shortend_configuration)
+            with open(config['outputDirectory']+'/'+stlFile, 'wb') as stream:
+                stream.write(stl)
+
+            stlMetadata = prefix.replace('/', '_')+'.part'
+            with open(config['outputDirectory']+'/'+stlMetadata, 'w', encoding="utf-8") as stream:
+                json.dump(part, stream, indent=4, sort_keys=True)
+
+            stlFile = config['outputDirectory']+'/'+stlFile
+
+        # Import the SCAD files pure shapes
+        shapes = None
+        if config['useScads']:
+            scadFile = prefix+'.scad'
+            if os.path.exists(config['outputDirectory']+'/'+scadFile):
+                shapes = csg.process(
+                    config['outputDirectory']+'/'+scadFile, config['pureShapeDilatation'])
+
+        # Obtain metadatas about part to retrieve color
+        if config['color'] is not None:
+            color = config['color']
+        else:
+            metadata = client.part_get_metadata(
+                part['documentId'], part['documentMicroversion'], part['elementId'], part['partId'], part['configuration'])
+            if 'appearance' in metadata:
+                colors = metadata['appearance']['color']
+                color = np.array(
+                    [colors['red'], colors['green'], colors['blue']])/255.0
+            else:
+                color = [0.5, 0.5, 0.5]
+
+        # Obtain mass properties about that part
+        if config['noDynamics']:
+            mass = 0
+            com = [0]*3
+            inertia = [0]*12
+        else:
+            if prefix in config['dynamicsOverride']:
+                entry = config['dynamicsOverride'][prefix]
+                mass = entry['mass']
+                com = entry['com']
+                inertia = entry['inertia']
+            else:
+                massProperties = client.part_mass_properties(
+                    part['documentId'], part['documentMicroversion'], part['elementId'], part['partId'], part['configuration'])
+
+                if part['partId'] not in massProperties['bodies']:
+                    print(Fore.YELLOW + 'WARNING: part ' +
+                        part['name']+' has no dynamics (maybe it is a surface)' + Style.RESET_ALL)
+                    return
+                massProperties = massProperties['bodies'][part['partId']]
+                mass = massProperties['mass'][0]
+                com = massProperties['centroid']
+                inertia = massProperties['inertia']
+
+                if abs(mass) < 1e-9:
+                    print(Fore.YELLOW + 'WARNING: part ' +
+                        part['name']+' has no mass, maybe you should assign a material to it ?' + Style.RESET_ALL)
+
+        pose = occurrence['transform']
+        if robot.relative:
+            pose = np.linalg.inv(matrix)*pose
+
+        robot.addPart(pose, stlFile, mass, com, inertia, color, shapes, prefix)
+
+
+    partNames = {}
+
+
+    def extractPartName(name, configuration):
+        parts = name.split(' ')
+        del parts[-1]
+        basePartName = '_'.join(parts).lower()
+
+        # only add configuration to name if its not default and not a very long configuration (which happens for library parts like screws)
+        if configuration != 'default' and len(configuration) < 40:
+            parts += ['_' + configuration.replace('=', '_').replace(' ', '_')]
+
+        return basePartName, '_'.join(parts).lower()
+
+
+    def processPartName(name, configuration, overrideName=None):
+        if overrideName is None:
+            global partNames
+            _, name = extractPartName(name, configuration)
+
+            if name in partNames:
+                partNames[name] += 1
+            else:
+                partNames[name] = 1
+
+            if partNames[name] == 1:
+                return name
+            else:
+                return name+'_'+str(partNames[name])
+        else:
+            return overrideName
+
+
+    def buildRobot(tree, matrix):
+        occurrence = getOccurrence([tree['id']])
+        instance = occurrence['instance']
+        print(Fore.BLUE + Style.BRIGHT +
+            '* Adding top-level instance ['+instance['name']+']' + Style.RESET_ALL)
+
+        # Build a part name that is unique but still informative
+        link = processPartName(
+            instance['name'], instance['configuration'], occurrence['linkName'])
+
+        # Create the link, collecting all children in the tree assigned to this top-level part
+        robot.startLink(link, matrix)
+        for occurrence in occurrences.values():
+            if occurrence['assignation'] == tree['id'] and occurrence['instance']['type'] == 'Part':
+                addPart(occurrence, matrix)
+        robot.endLink()
+
+        # Adding the frames (linkage is relative to parent)
+        if tree['id'] in frames:
+            for name, part in frames[tree['id']]:
+                frame = getOccurrence(part)['transform']
+                if robot.relative:
+                    frame = np.linalg.inv(matrix)*frame
+                robot.addFrame(name, frame)
+
+        # Following the children in the tree, calling this function recursively
+        k = 0
+        for child in tree['children']:
+            worldAxisFrame = child['axis_frame']
+            zAxis = child['z_axis']
+            jointType = child['jointType']
+            jointLimits = child['jointLimits']
+
+            if robot.relative:
+                axisFrame = np.linalg.inv(matrix)*worldAxisFrame
+                childMatrix = worldAxisFrame
+            else:
+                # In SDF format, everything is expressed in the world frame, in this case
+                # childMatrix will be always identity
+                axisFrame = worldAxisFrame
+                childMatrix = matrix
+
+            subLink = buildRobot(child, childMatrix)
+            robot.addJoint(jointType, link, subLink, axisFrame,
+                        child['dof_name'], jointLimits, zAxis)
+
+        return link
+
+
+    # Start building the robot
+    buildRobot(tree, np.matrix(np.identity(4)))
+    robot.finalize()
+    # print(tree)
+
+    print("\n" + Style.BRIGHT + "* Writing " +
+        robot.ext.upper()+" file" + Style.RESET_ALL)
+    with open(config['outputDirectory']+'/robot.'+robot.ext, 'w', encoding="utf-8") as stream:
+        stream.write(robot.xml)
+
+    if len(config['postImportCommands']):
+        print("\n" + Style.BRIGHT + "* Executing post-import commands" + Style.RESET_ALL)
+        for command in config['postImportCommands']:
+            print("* "+command)
+            os.system(command)
+
+
+if __name__ == "__main__":
+    main()

--- a/onshape_to_robot/onshape_to_robot.py
+++ b/onshape_to_robot/onshape_to_robot.py
@@ -86,14 +86,12 @@ def addPart(occurrence, matrix):
             shortend_configuration = part['configuration']
         stl = client.part_studio_stl_m(part['documentId'], part['documentMicroversion'], part['elementId'],
                                        part['partId'], shortend_configuration)
-        f = open(config['outputDirectory']+'/'+stlFile, 'wb')
-        f.write(stl)
-        f.close()
+        with open(config['outputDirectory']+'/'+stlFile, 'wb', encoding="utf-8") as stream:
+            stream.write(stl)
 
         stlMetadata = prefix.replace('/', '_')+'.part'
-        f = open(config['outputDirectory']+'/'+stlMetadata, 'wb')
-        f.write(json.dumps(part).encode('UTF-8'))
-        f.close()
+        with open(config['outputDirectory']+'/'+stlMetadata, 'wb', encoding="utf-8") as stream:
+            stream.write(json.dumps(part).encode('UTF-8'))
 
         stlFile = config['outputDirectory']+'/'+stlFile
 
@@ -242,9 +240,8 @@ robot.finalize()
 
 print("\n" + Style.BRIGHT + "* Writing " +
       robot.ext.upper()+" file" + Style.RESET_ALL)
-f = open(config['outputDirectory']+'/robot.'+robot.ext, 'w')
-f.write(robot.xml)
-f.close()
+with open(config['outputDirectory']+'/robot.'+robot.ext, 'w', encoding="utf-8") as stream:
+    stream.write(robot.xml)
 
 if len(config['postImportCommands']):
     print("\n" + Style.BRIGHT + "* Executing post-import commands" + Style.RESET_ALL)

--- a/onshape_to_robot/pure_sketch.py
+++ b/onshape_to_robot/pure_sketch.py
@@ -24,8 +24,8 @@ else:
     parts[-1] = 'scad'
     scadFileName = '.'.join(parts)
 
-    f = open(partFileName, 'r')
-    part = json.load(f)
+    with open(partFileName, 'r', encoding="utf-8") as stream:
+        part = json.load(stream)
     partid = part['partId']
     result = client.get_sketches(part['documentId'], part['documentMicroversion'], part['elementId'], part['configuration'])
 
@@ -108,14 +108,10 @@ else:
             scad += "}\n"
             scad += "}\n"
 
-        f = open(scadFileName, 'w')
-        f.write(scad)
-        f.close()
+        with open(scadFileName, 'w', encoding="utf-8") as stream:
+            stream.write(scad)
 
         directory = os.path.dirname(fileName)
         os.system('cd '+directory+'; openscad '+os.path.basename(scadFileName))
     else:
         print(Fore.RED + "ERROR: Can't find pure shape sketch in this part" + Style.RESET_ALL)
-
-
-    

--- a/onshape_to_robot/pure_sketch.py
+++ b/onshape_to_robot/pure_sketch.py
@@ -5,113 +5,119 @@ import os
 import sys, os
 from colorama import Fore, Back, Style
 
-if len(sys.argv) < 2:
-    print('Usage: onshape-to-robot-pure-shape {STL file} [prefix=PureShapes]')
-else:
-    fileName = sys.argv[1]
-    robotDir = os.path.dirname(fileName)
-    configFile = os.path.join(robotDir, 'config.json')
-    prefix = 'PureShapes'
-    if len(sys.argv) > 2:
-        prefix = sys.argv[2]
 
-    from .onshape_api.client import Client
-    client = Client(logging=False, creds=configFile)
-    
-    parts = fileName.split('.')
-    parts[-1] = 'part'
-    partFileName = '.'.join(parts)
-    parts[-1] = 'scad'
-    scadFileName = '.'.join(parts)
-
-    with open(partFileName, 'r', encoding="utf-8") as stream:
-        part = json.load(stream)
-    partid = part['partId']
-    result = client.get_sketches(part['documentId'], part['documentMicroversion'], part['elementId'], part['configuration'])
-
-    scad = "% scale(1000) import(\""+os.path.basename(fileName)+"\");\n"
-
-    sketchDatas = []
-    for sketch in result['sketches']:
-        if sketch['sketch'].startswith(prefix):
-            parts = sketch['sketch'].split(' ')
-            if len(parts) >= 2:
-                sketch['thickness'] = float(parts[1])
-            else:
-                print(Fore.RED + "ERROR: The sketch name should contain extrusion size (e.g \"PureShapes 5.3\")"
-                    + Style.RESET_ALL)
-                exit(0)
-            sketchDatas.append(sketch)
-    
-    if len(sketchDatas):
-        print(Fore.GREEN + "* Found "+str(len(sketchDatas))+" PureShapes sketches" + Style.RESET_ALL)
-        for sketchData in sketchDatas:
-            # Retrieving sketch transform matrix
-            m = sketchData['transformMatrix']
-            mm = [m[0:4], m[4:8], m[8:12], m[12:16]]
-            mm[0][3] *= 1000
-            mm[1][3] *= 1000
-            mm[2][3] *= 1000
-            scad += "\n"
-            scad += "// Sketch "+sketchData['sketch']+"\n"
-            scad += 'multmatrix('+str(mm)+') {'+"\n"
-            scad += "thickness = %f;\n" % sketchData['thickness']
-            scad += "translate([0, 0, -thickness]) {\n"
-
-            boxes = {}
-
-            def boxSet(id, pointName, point):
-                if id not in boxes:
-                    boxes[id] = {}
-                boxes[id][pointName] = point
-            
-            for entry in sketchData['geomEntities']:
-                if entry['entityType'] == 'circle':
-                    center = entry['center']
-                    scad += "  translate([%f, %f, 0]) {\n" % (center[0]*1000, center[1]*1000)
-                    scad += "    cylinder(r=%f,h=thickness);\n" % (entry['radius']*1000)
-                    scad += "  }\n"
-                if entry['entityType'] == 'point':
-                    parts = entry['id'].split('.')
-                    if len(parts) == 3:
-                        if parts[1] == 'top' and parts[2] == 'start':
-                            boxSet(parts[0], 'A', entry['point'])
-                        if parts[1] == 'top' and parts[2] == 'end':
-                            boxSet(parts[0], 'B', entry['point'])
-                        if parts[1] == 'bottom' and parts[2] == 'start':
-                            boxSet(parts[0], 'C', entry['point'])
-                        if parts[1] == 'bottom' and parts[2] == 'end':
-                            boxSet(parts[0], 'D', entry['point'])
-
-            for id in boxes:
-                if len(boxes[id]) == 4:
-                    A, B = np.array(boxes[id]['A']), np.array(boxes[id]['B'])
-                    C, D = np.array(boxes[id]['C']), np.array(boxes[id]['D'])
-                    AB = B-A
-
-                    # Making sure that the orientation of the square is correct
-                    AB90 = np.array([-AB[1], AB[0]])
-                    side = AB90.dot(C-A)
-                    width = np.linalg.norm(B-A)
-                    height = np.linalg.norm(B-D)
-                    if side < 0:
-                        A, B, C, D = C, D, A, B
-
-                    AB = B-A
-                    alpha = np.rad2deg(math.atan2(AB[1], AB[0]))
-                    scad += "  translate([%f, %f, 0]) {\n" % (A[0]*1000, A[1]*1000)
-                    scad += '    rotate([0, 0, '+str(alpha)+']) {'+"\n"
-                    scad += "      cube([%f, %f, thickness]);\n" % (width*1000, height*1000)
-                    scad += "    }\n"
-                    scad += "  }\n"
-            
-            scad += "}\n"
-            scad += "}\n"
-
-        with open(scadFileName, 'w', encoding="utf-8") as stream:
-            stream.write(scad)
-
-        directory = os.path.dirname(fileName)
-        os.system('cd '+directory+'; openscad '+os.path.basename(scadFileName))
+def main():
+    if len(sys.argv) < 2:
+        print('Usage: onshape-to-robot-pure-shape {STL file} [prefix=PureShapes]')
     else:
-        print(Fore.RED + "ERROR: Can't find pure shape sketch in this part" + Style.RESET_ALL)
+        fileName = sys.argv[1]
+        robotDir = os.path.dirname(fileName)
+        configFile = os.path.join(robotDir, 'config.json')
+        prefix = 'PureShapes'
+        if len(sys.argv) > 2:
+            prefix = sys.argv[2]
+
+        from .onshape_api.client import Client
+        client = Client(logging=False, creds=configFile)
+
+        parts = fileName.split('.')
+        parts[-1] = 'part'
+        partFileName = '.'.join(parts)
+        parts[-1] = 'scad'
+        scadFileName = '.'.join(parts)
+
+        with open(partFileName, 'r', encoding="utf-8") as stream:
+            part = json.load(stream)
+        partid = part['partId']
+        result = client.get_sketches(part['documentId'], part['documentMicroversion'], part['elementId'], part['configuration'])
+
+        scad = "% scale(1000) import(\""+os.path.basename(fileName)+"\");\n"
+
+        sketchDatas = []
+        for sketch in result['sketches']:
+            if sketch['sketch'].startswith(prefix):
+                parts = sketch['sketch'].split(' ')
+                if len(parts) >= 2:
+                    sketch['thickness'] = float(parts[1])
+                else:
+                    print(Fore.RED + "ERROR: The sketch name should contain extrusion size (e.g \"PureShapes 5.3\")"
+                        + Style.RESET_ALL)
+                    exit(0)
+                sketchDatas.append(sketch)
+
+        if len(sketchDatas):
+            print(Fore.GREEN + "* Found "+str(len(sketchDatas))+" PureShapes sketches" + Style.RESET_ALL)
+            for sketchData in sketchDatas:
+                # Retrieving sketch transform matrix
+                m = sketchData['transformMatrix']
+                mm = [m[0:4], m[4:8], m[8:12], m[12:16]]
+                mm[0][3] *= 1000
+                mm[1][3] *= 1000
+                mm[2][3] *= 1000
+                scad += "\n"
+                scad += "// Sketch "+sketchData['sketch']+"\n"
+                scad += 'multmatrix('+str(mm)+') {'+"\n"
+                scad += "thickness = %f;\n" % sketchData['thickness']
+                scad += "translate([0, 0, -thickness]) {\n"
+
+                boxes = {}
+
+                def boxSet(id, pointName, point):
+                    if id not in boxes:
+                        boxes[id] = {}
+                    boxes[id][pointName] = point
+
+                for entry in sketchData['geomEntities']:
+                    if entry['entityType'] == 'circle':
+                        center = entry['center']
+                        scad += "  translate([%f, %f, 0]) {\n" % (center[0]*1000, center[1]*1000)
+                        scad += "    cylinder(r=%f,h=thickness);\n" % (entry['radius']*1000)
+                        scad += "  }\n"
+                    if entry['entityType'] == 'point':
+                        parts = entry['id'].split('.')
+                        if len(parts) == 3:
+                            if parts[1] == 'top' and parts[2] == 'start':
+                                boxSet(parts[0], 'A', entry['point'])
+                            if parts[1] == 'top' and parts[2] == 'end':
+                                boxSet(parts[0], 'B', entry['point'])
+                            if parts[1] == 'bottom' and parts[2] == 'start':
+                                boxSet(parts[0], 'C', entry['point'])
+                            if parts[1] == 'bottom' and parts[2] == 'end':
+                                boxSet(parts[0], 'D', entry['point'])
+
+                for id in boxes:
+                    if len(boxes[id]) == 4:
+                        A, B = np.array(boxes[id]['A']), np.array(boxes[id]['B'])
+                        C, D = np.array(boxes[id]['C']), np.array(boxes[id]['D'])
+                        AB = B-A
+
+                        # Making sure that the orientation of the square is correct
+                        AB90 = np.array([-AB[1], AB[0]])
+                        side = AB90.dot(C-A)
+                        width = np.linalg.norm(B-A)
+                        height = np.linalg.norm(B-D)
+                        if side < 0:
+                            A, B, C, D = C, D, A, B
+
+                        AB = B-A
+                        alpha = np.rad2deg(math.atan2(AB[1], AB[0]))
+                        scad += "  translate([%f, %f, 0]) {\n" % (A[0]*1000, A[1]*1000)
+                        scad += '    rotate([0, 0, '+str(alpha)+']) {'+"\n"
+                        scad += "      cube([%f, %f, thickness]);\n" % (width*1000, height*1000)
+                        scad += "    }\n"
+                        scad += "  }\n"
+
+                scad += "}\n"
+                scad += "}\n"
+
+            with open(scadFileName, 'w', encoding="utf-8") as stream:
+                stream.write(scad)
+
+            directory = os.path.dirname(fileName)
+            os.system('cd '+directory+'; openscad '+os.path.basename(scadFileName))
+        else:
+            print(Fore.RED + "ERROR: Can't find pure shape sketch in this part" + Style.RESET_ALL)
+
+
+if __name__ == "__main__":
+    main()

--- a/onshape_to_robot/stl_combine.py
+++ b/onshape_to_robot/stl_combine.py
@@ -61,8 +61,8 @@ filter_script_mlx = """<!DOCTYPE FilterScript>
 
 
 def create_tmp_filter_file(filename='filter_file_tmp.mlx', reduction=0.9):
-    with open('/tmp/' + filename, 'w') as f:
-        f.write(filter_script_mlx.replace('%reduction%', str(reduction)))
+    with open('/tmp/' + filename, 'w', encoding="utf-8") as stream:
+        stream.write(filter_script_mlx.replace('%reduction%', str(reduction)))
     return '/tmp/' + filename
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,11 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     entry_points={
         "console_scripts": [
-            "onshape-to-robot=onshape_to_robot:onshape_to_robot",
-            "onshape-to-robot-bullet=onshape_to_robot:bullet",
-            "onshape-to-robot-clear-cache=onshape_to_robot:clear_cache",
-            "onshape-to-robot-edit-shape=onshape_to_robot:edit_shape",
-            "onshape-to-robot-pure-sketch=onshape_to_robot:pure_sketch",
+            "onshape-to-robot=onshape_to_robot:onshape_to_robot.main",
+            "onshape-to-robot-bullet=onshape_to_robot:bullet.main",
+            "onshape-to-robot-clear-cache=onshape_to_robot:clear_cache.main",
+            "onshape-to-robot-edit-shape=onshape_to_robot:edit_shape.main",
+            "onshape-to-robot-pure-sketch=onshape_to_robot:pure_sketch.main",
         ]
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
-with open("README-pypi.md", "r") as fh:
-    long_description = fh.read()
+with open("README-pypi.md", "r", encoding="utf-8") as stream:
+    long_description = stream.read()
 
 setuptools.setup(
     name="onshape-to-robot",


### PR DESCRIPTION
It looks like a lot of lines, but really it's mostly indenting code in scripts
to avoid unexpected side effects when importing modules.

Modify script modules such that functionality is wrapped in a function
call. This prevents unexpected behavior when importing a module. This
also fixes an issue I had installing and running these entrypoints on
a different environment than I had previously tested on.

Also move the cache path from the location of the onshape_api module to
the user's home directory. This handles environments where the package
is installed globally, in which case the previous cache directory
location is not generally writeable by the user.

**Note that this PR includes https://github.com/Rhoban/onshape-to-robot/issues/64, so that should be merged first, or this PR can be adapted if the previous PR is not wanted.**

See also: https://github.com/Rhoban/onshape-to-robot/issues/63
See also: https://github.com/Rhoban/onshape-to-robot/issues/64