### PR TITLE
Fix package path concatenation for meshes

### DIFF
--- a/onshape_to_robot/robot_description.py
+++ b/onshape_to_robot/robot_description.py
@@ -257,7 +257,7 @@ class RobotURDF(RobotDescription):
         self.append(origin(matrix))
         self.append('<geometry>')
         self.append('<mesh filename="package://' +
-                    self.packageName + stl+'"/>')
+                    self.packageName.strip("/") + "/" + stl+'"/>')
         self.append('</geometry>')
         self.append('<material name="'+name+'_material">')
         self.append('<color rgba="%g %g %g 1.0"/>' %


### PR DESCRIPTION
Ensure that the package path for the mesh in the URDF is generated
correctly with a `/` between the package name and the file name.