### PR TITLE
Raise Python minimum version to 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setuptools.setup(
     ],
     include_package_data=True,
     package_data={'': ['bullet/*', 'README.md']},
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
Raise Python minimum version to 3.7

Currently, this package is set to require Python >= 3.6. I propose
bumping to Python >= 3.7 since Python 3.6 is no longer receiving
security updates.

**Be aware this will almost certainly break things for some users.**
Ubuntu 18.04 ships with Python 3.6 so a user would have to use pyenv,
virtualenv, a different PPA, or some other method for installing Python
or use a Docker container to run this code. Ubuntu 18.04 is still
relatively widely used. Ubuntu 20.04 ships with Python 3.8.

I have created a prototype Dockerfile in a fork that containerizes this
application so that approach seems reasonable and does work. It is also
fairly straightforward to install pyenv and that is how I've always run
this package.

I suggest this as a good time for an upgrade because the API for
ttps://bootstrap.pypa.io/get-pip.py just deprecated Python 3.6.