### PR TITLE
support continuous joints

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -11,7 +11,11 @@ Specifying degrees of freedom
 
 * Degree of freedoms should be slider, cylindrical or revolute mate connectors named ``dof_something``, where
   ``something`` will be used to name the joint in the final document
-  * If the mate connector is **cylindrical** or **revolute**, a ``revolute`` joint will be issued
+
+  * If the mate connector is **cylindrical** or **revolute**, a ``revolute`` joint will be issued by default
+  
+    * To make a ``continuous`` joint, add ``continuous`` or ``wheel`` in the name of the joint. For instance, a **revolute** mate named
+      ``dof_front_left_wheel`` will result in a ``continuous`` joint named ``front_left_wheel`` in the resulting URDF.
   * If the mate connector is a **slider**, a ``prismatic`` joint will be issued
   * If the mate connector is **fastened**, a ``fixed`` joint will be issued
 * When doing this connection, click the children joint first. This will be used to find the trunk of the robot (part with children but no parent)

--- a/onshape_to_robot/features.py
+++ b/onshape_to_robot/features.py
@@ -102,6 +102,7 @@ def getLimits(jointType, name):
     if enabled:
         return (minimum, maximum)
     else:
-        print(Fore.YELLOW + 'WARNING: joint ' + name + ' of type ' +
-              jointType + ' has no limits ' + Style.RESET_ALL)
+        if jointType != 'continuous':
+            print(Fore.YELLOW + 'WARNING: joint ' + name + ' of type ' +
+                jointType + ' has no limits ' + Style.RESET_ALL)
         return None

--- a/onshape_to_robot/load_robot.py
+++ b/onshape_to_robot/load_robot.py
@@ -167,7 +167,10 @@ for feature in features:
 
             limits = None
             if data['mateType'] == 'REVOLUTE' or data['mateType'] == 'CYLINDRICAL':
-                jointType = 'revolute'
+                if 'wheel' in parts or 'continuous' in parts:
+                    jointType = 'continuous'
+                else:
+                    jointType = 'revolute'
 
                 if not config['ignoreLimits']:
                     limits = getLimits(jointType, data['name'])


### PR DESCRIPTION
Cylindrical and Revolute Onshape mates with "continuous" or "wheel" in the name are created as continuous joints. Addresses part of #99. 
* docs updated for new feature (also fixed existing syntax error with bullets in docs)
* removed warning about missing joint limits for continuous, because not applicable.

I tested and confirmed the functionality of my changes using a known good Onshape assembly.