### PR TITLE
Use url encoding on part id

### DIFF
--- a/onshape_to_robot/onshape_api/client.py
+++ b/onshape_to_robot/onshape_api/client.py
@@ -13,10 +13,11 @@ import string
 import os
 import json
 import hashlib
+import urllib.parse
 from pathlib import Path
 
-def escape_slash(s):
-    return s.replace('/', '%2f')
+def urlencode(s):
+    return urllib.parse.quote(s)
 
 class Client():
     '''
@@ -338,18 +339,18 @@ class Client():
             req_headers = {
                 'Accept': '*/*'
             }
-            return self._api.request('get', '/api/parts/d/' + did + '/m/' + mid + '/e/' + eid + '/partid/'+escape_slash(partid)+'/stl', query={'mode': 'binary', 'units': 'meter', 'configuration': configuration}, headers=req_headers)
+            return self._api.request('get', '/api/parts/d/' + did + '/m/' + mid + '/e/' + eid + '/partid/'+urlencode(partid)+'/stl', query={'mode': 'binary', 'units': 'meter', 'configuration': configuration}, headers=req_headers)
 
         return self.cache_get('part_stl', (did, mid, eid, self.hash_partid(partid), configuration), invoke)
 
     def part_get_metadata(self, did, mid, eid, partid, configuration = 'default'):
         def invoke():
-            return self._api.request('get', '/api/metadata/d/' + did + '/m/' + mid + '/e/' + eid + '/p/'+escape_slash(partid), query={'configuration': configuration})
+            return self._api.request('get', '/api/metadata/d/' + did + '/m/' + mid + '/e/' + eid + '/p/'+urlencode(partid), query={'configuration': configuration})
 
         return json.loads(self.cache_get('metadata', (did, mid, eid, self.hash_partid(partid), configuration), invoke, True))
 
     def part_mass_properties(self, did, mid, eid, partid, configuration = 'default'):
         def invoke():
-            return self._api.request('get', '/api/parts/d/' + did + '/m/' + mid + '/e/' + eid + '/partid/'+escape_slash(partid)+'/massproperties', query={'configuration': configuration, 'useMassPropertyOverrides': True})
+            return self._api.request('get', '/api/parts/d/' + did + '/m/' + mid + '/e/' + eid + '/partid/'+urlencode(partid)+'/massproperties', query={'configuration': configuration, 'useMassPropertyOverrides': True})
 
         return json.loads(self.cache_get('massproperties', (did, mid, eid, self.hash_partid(partid), configuration), invoke, True))


### PR DESCRIPTION
Recently, I've been trying to create an SDF file from an Onshape document, but it fails and tells me that some URL returns a 404 error. It turns out that this happens because the part ID contains a plus (+) character. I also came across issue #46 which fixes the unescaped slash problem. However, part IDs can also contain plus signs and possibly other characters. Therefore, I believe it would be best to URL encode the entire part ID. I also changed the function name since it no longer just escapes the slash.