### PR TITLE
Windows openSCAD detection and color output fix

### DIFF
--- a/onshape_to_robot/config.py
+++ b/onshape_to_robot/config.py
@@ -2,8 +2,10 @@ from sys import exit
 import sys
 import os
 import commentjson as json
-from colorama import Fore, Back, Style
+import subprocess
+from colorama import Fore, Back, Style, just_fix_windows_console
 
+just_fix_windows_console()
 config = {}
 
 # Loading configuration & parameters
@@ -122,13 +124,18 @@ except OSError:
 # Checking that OpenSCAD is present
 if config['useScads']:
     print(Style.BRIGHT + '* Checking OpenSCAD presence...' + Style.RESET_ALL)
-    if os.system('openscad -v 2> /dev/null') != 0:
+    try:
+        subprocess.run(["openscad", "-v"])
+    except FileNotFoundError:
         print(
             Fore.RED + "Can't run openscad -v, disabling OpenSCAD support" + Style.RESET_ALL)
         print(Fore.BLUE + "TIP: consider installing openscad:" + Style.RESET_ALL)
+        print(Fore.BLUE + "Linux:" + Style.RESET_ALL)
         print(Fore.BLUE + "sudo add-apt-repository ppa:openscad/releases" + Style.RESET_ALL)
         print(Fore.BLUE + "sudo apt-get update" + Style.RESET_ALL)
         print(Fore.BLUE + "sudo apt-get install openscad" + Style.RESET_ALL)
+        print(Fore.BLUE + "Windows:" + Style.RESET_ALL)
+        print(Fore.BLUE + "go to: https://openscad.org/downloads.html " + Style.RESET_ALL)
         config['useScads'] = False
 
 # Checking that MeshLab is present


### PR DESCRIPTION
## What
This pull request:
1) enables OpenSCAD detection on Windows
2) resolves a color output inconsistency issue on Windows consoles.
## Why
1) OpenSCAD detection was not available on Windows systems.
2) OpenSCAD detection changes introduced a color output  inconsistencies on Windows consoles.
## How
### OpenSCAD Detection
I replaced `os.system()` with `subprocess.run()` for executing `openscad -v`
### Colorama Solution
Calls `just_fix_windows_console()` function from the `colorama` library to address the color output inconsistency. 
## Visual Demos
Screenshots below illustrate the impact of the changes. These showcase code output comparisons before and after the modifications. It covers both Windows and Linux environments while OpenSCAD is installed
### Before and After Screenshots
1. [Windows Before - Unable to detect](https://github.com/Rhoban/onshape-to-robot/assets/85626643/e6d71e38-992b-4924-83fa-41fb77a73b0b)
2. [Windows After 1. - Color output inconsistency](https://github.com/Rhoban/onshape-to-robot/assets/85626643/a2072aaa-2920-4b5a-b877-48c078e9cd07)
3. [Windows After 1. and 2. - Consistent color output](https://github.com/Rhoban/onshape-to-robot/assets/85626643/85dc4681-4300-4f19-b014-42de2e8c414d)
4. [Linux (wsl2) Before - Works](https://github.com/Rhoban/onshape-to-robot/assets/85626643/b7e1d16a-9e18-4528-a5b1-aaabba83d4c6)
5. [Linux (wsl2) After - Still works](https://github.com/Rhoban/onshape-to-robot/assets/85626643/056317ba-e657-44c0-82e0-e69c7a883aa6)


