### PR TITLE
Add standard content mass properties retrieval

### DIFF
--- a/onshape_to_robot/onshape_api/client.py
+++ b/onshape_to_robot/onshape_api/client.py
@@ -352,4 +352,10 @@ class Client():
         def invoke():
             return self._api.request('get', '/api/parts/d/' + did + '/m/' + mid + '/e/' + eid + '/partid/'+escape_slash(partid)+'/massproperties', query={'configuration': configuration, 'useMassPropertyOverrides': True})
 
-        return json.loads(self.cache_get('massproperties', (did, mid, eid, self.hash_partid(partid), configuration), invoke, True))
+        return json.loads(self.cache_get('part_massproperties', (did, mid, eid, self.hash_partid(partid), configuration), invoke, True))
+    
+    def standard_cont_mass_properties(self, did, vid, eid, partid, linkDocumentId, configuration):
+        def invoke():
+            return self._api.request('get', '/api/parts/d/' + did + '/v/' + vid + '/e/' + eid + '/partid/'+escape_slash(partid)+'/massproperties', query={'configuration': configuration, 'useMassPropertyOverrides': True, "linkDocumentId": linkDocumentId, "inferMetadataOwner": True})
+
+        return json.loads(self.cache_get('standard_massproperties', (did, vid, eid, self.hash_partid(partid), configuration), invoke, True))

--- a/onshape_to_robot/onshape_to_robot.py
+++ b/onshape_to_robot/onshape_to_robot.py
@@ -133,8 +133,12 @@ def main():
                 com = entry['com']
                 inertia = entry['inertia']
             else:
-                massProperties = client.part_mass_properties(
-                    part['documentId'], part['documentMicroversion'], part['elementId'], part['partId'], part['configuration'])
+                if part['isStandardContent']:
+                    massProperties = client.standard_cont_mass_properties(
+                        part['documentId'], part['documentVersion'], part['elementId'], part['partId'],config['documentId'], part['configuration'])
+                else:
+                    massProperties = client.part_mass_properties(
+                        part['documentId'], part['documentMicroversion'], part['elementId'], part['partId'], part['configuration'])
 
                 if part['partId'] not in massProperties['bodies']:
                     print(Fore.YELLOW + 'WARNING: part ' +


### PR DESCRIPTION
### Summary
Adds `standard_cont_mass_properties` method to the `Client` class, enabling mass properties retrieval for standard content. 

### Testing
Testing was done using this [onshape document](https://cad.onshape.com/documents/017f1c2072e843891025e97d/w/3d653d232bb5b46cbdfc21c6/e/45b2f6a5cd97e5c57fe8e5a6)
After the changes the inertial tag for `sub-asm-std-cont` matches with the `display mass properties` window within onshape. 

Inertial tag:
```urdf
<inertial>
<origin xyz="3.9625718201122967351e-10 7.420351968363106984e-05 0.099769642737675509614" rpy="0 0 0"/>
<mass value="0.77420617546130443554" />
<inertia ixx="0.0026100719639290674741" ixy="-4.500337705738727131e-12"  ixz="1.3282237023637959534e-11" iyy="0.0026078954199623763377" iyz="3.4736360265661929318e-06" izz="6.2401832920398126923e-05" />
</inertial>
```
Output from [display mass properties](https://github.com/Rhoban/onshape-to-robot/assets/85626643/8cb9fefb-6c5a-4d12-9833-503d867f975e)

Closes: #102 