### PR TITLE
Update readme for config.rst

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -209,12 +209,19 @@ Adds a ``base_link`` without inertia as root. This is often necessary for ROS us
 
 Specifies the robot name.
 
-``additionalXML``
+``additionalUrdfFile``
 ~~~~~~~~~~~~~~~~~
 
 *optional*
 
-Specifies a file with XML content that is inserted into the URDF/SDF at the end of the file. Useful to add things that can't be modelled in onshape, e.g. simulated sensors.
+Specifies a file with XML content that is inserted into the URDF at the end of the file. Useful to add things that can't be modelled in onshape, e.g. simulated sensors.
+
+``additionalSdfFile``
+~~~~~~~~~~~~~~~~~
+
+*optional*
+
+The same as ``additionalUrdfFile`` but for the SDF output.
 
 ``useFixedLinks``
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As mentioned on the documentation [here](https://onshape-to-robot.readthedocs.io/en/latest/config.html#additionalxml), the parameter does not seem to work.

Upon looking into the [code](https://github.com/Rhoban/onshape-to-robot/blob/2105c20abb369a1b71ab67759568140be229fc8f/onshape_to_robot/config.py#L97),  we can see that the parameter `additionalUrdfFile` and `additionalSdfFile` are being read from the `config.json` and later being stored inside a dict `config["additionalXmlFile"]`.

I have just updated the docs with the values that are being read from the config file.