### PR TITLE
Added support for dotenv files

### DIFF
--- a/onshape_to_robot/onshape_api/onshape.py
+++ b/onshape_to_robot/onshape_api/onshape.py
@@ -20,6 +20,7 @@ import requests
 from colorama import Fore, Back, Style
 from urllib.parse import urlparse
 from urllib.parse import parse_qs
+from dotenv import load_dotenv
 
 __all__ = [
     'Onshape'
@@ -68,6 +69,8 @@ class Onshape():
             except TypeError as ex:
                 raise ValueError('%s is not valid json' % creds) from ex
 
+        #No idea why the name of the dotenv file needed to be spesified but the code breaks without it.
+        load_dotenv(".env")
         try:
             self._url = config["onshape_api"]
             self._access_key = config['onshape_access_key'].encode('utf-8')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests
 sphinx
 sphinx-rtd-theme
 transforms3d
+python-dotenv

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     ],
     keywords="robot robotics cad design onshape bullet pybullet sdf urdf gazebo ros model kinematics",
     install_requires=[
-        "numpy", "pybullet", "requests", "commentjson", "colorama>=0.4.6", "numpy-stl", "transforms3d"
+        "numpy", "pybullet", "requests", "commentjson", "colorama>=0.4.6", "numpy-stl", "transforms3d", "python-dotenv"
     ],
     include_package_data=True,
     package_data={'': ['bullet/*', 'README.md']},


### PR DESCRIPTION
This PR adds support for the popular .env file.

This way you can store your onshape keys in a file that you can safely gitignore instead of storing the keys in your config or bashrc.

I tried to change as little as possible.

I tested this on one of my repos that I have been working on and it seems to work well.

Thanks for your great work.