### PR TITLE
allowing to use `onshape-to-robot` command with a path pointing to the `.json` file itself

### DIFF
--- a/onshape_to_robot/config.py
+++ b/onshape_to_robot/config.py
@@ -8,7 +8,13 @@ from .message import error, bright, info
 
 class Config:
     def __init__(self, robot_path: str):
-        self.config_file: str = robot_path + "/config.json"
+
+        self.config_file: str = robot_path
+        if not robot_path.endswith(".json"):
+            self.config_file: str = robot_path + "/config.json"
+            self.robot_root_path = robot_path
+        else:
+            self.robot_root_path = os.path.dirname(os.path.abspath(robot_path))
 
         # Loading JSON configuration
         if not os.path.exists(self.config_file):
@@ -22,7 +28,7 @@ class Config:
         self.read_configuration()
 
         # Output directory, making it if it doesn't exists
-        self.output_directory: str = robot_path
+        self.output_directory: str = self.robot_root_path
 
         if self.robot_name is None:
             self.robot_name = os.path.dirname(os.path.abspath(self.config_file)).split(

--- a/onshape_to_robot/config.py
+++ b/onshape_to_robot/config.py
@@ -8,13 +8,8 @@ from .message import error, bright, info
 
 class Config:
     def __init__(self, robot_path: str):
-
-        self.config_file: str = robot_path
-        if not robot_path.endswith(".json"):
-            self.config_file: str = robot_path + "/config.json"
-            self.robot_root_path = robot_path
-        else:
-            self.robot_root_path = os.path.dirname(os.path.abspath(robot_path))
+        if os.path.isdir(robot_path):
+            robot_path += os.path.sep + "config.json"
 
         # Loading JSON configuration
         if not os.path.exists(self.config_file):
@@ -28,7 +23,7 @@ class Config:
         self.read_configuration()
 
         # Output directory, making it if it doesn't exists
-        self.output_directory: str = self.robot_root_path
+        self.output_directory: str = os.path.dirname(os.path.abspath(robot_path))
 
         if self.robot_name is None:
             self.robot_name = os.path.dirname(os.path.abspath(self.config_file)).split(


### PR DESCRIPTION
Sometimes it's useful to have multiple `config.json` files, for example I have one to export a `URDF` and one to export a `MJCF`. 

This PR allows executing `onshape-to-robot <path>/config_urdf.json` for example, instead having to supply only the root folder, and the command would look for a `config.json`.

The previous behavior is still compatible, if you don't supply the path to the json but only to the folder, it still looks for `config.json` in this folder