### PR TITLE
Fix openscad parser indescriminately replacing all collision meshes 

### DIFF
--- a/onshape_to_robot/processor_scad.py
+++ b/onshape_to_robot/processor_scad.py
@@ -54,7 +54,7 @@ class ProcessorScad(Processor):
                             scad_file = mesh.filename.replace(".stl", ".scad")
                             if os.path.exists(scad_file):
                                 part.shapes += self.parse_scad(scad_file, mesh.color)
-                            converted_meshes.append(mesh)
+                                converted_meshes.append(mesh)
 
                     for converted_mesh in converted_meshes:
                         converted_mesh.collision = False


### PR DESCRIPTION
# Issue
Current behaviour of the code for replacing meshes with pure shapes is not in line with the documentation as presented in the [documentation video](https://youtu.be/C8oK4uUmbRw?t=1651).

# Current behaviour
If `ProcessorScad` is used, it goes through all collision meshes. If there is no `*.scad` file for a given mesh, it still gets replaced with nothing (`mesh.collision = False`)

# New behaviour
If `ProcessorScad` is used, it only uses pure shapes to replace meshes for which `*.scad` files exist, leaving all other meshes intact.