### PR TITLE
Fixes issue with pure_sketch.py not finding config files

### DIFF
--- a/onshape_to_robot/pure_sketch.py
+++ b/onshape_to_robot/pure_sketch.py
@@ -20,24 +20,16 @@ def main():
         default="PureShapes",
         help="Prefix for pure shape sketches (default: PureShapes)",
     )
-    parser.add_argument(
-        "--config",
-        type=str,
-        help="Configuration file location (default: looks for config.json in the part folder or its parent folder)",
-    )
     args = parser.parse_args()
 
     fileName = args.file
     prefix = args.prefix
-    if args.config:
-        configFile = args.config
-    else:
-        robotDir = os.path.dirname(fileName)
-        configFile = os.path.join(robotDir, "config.json")
+    robotDir = os.path.dirname(fileName)
+    configFile = os.path.join(robotDir, "config.json")
+    if os.path.exists(configFile) == False:
+        configFile = os.path.join(robotDir, "..", "config.json")
         if os.path.exists(configFile) == False:
-            configFile = os.path.join(robotDir, "..", "config.json")
-            if os.path.exists(configFile) == False:
-                raise Exception(f"ERROR: The config file {configFile} can't be found")
+            raise Exception(f"ERROR: The config file {configFile} can't be found")
 
     from .onshape_api.client import Client
 


### PR DESCRIPTION
Issue:
The pure sketch functionality did not work when the config file was not in the same folder as the STL files, as is default in the current version of onshape_to_robot (by default STL are stored in a subfolder called /assets)

Solution:
This PR has a three step procedure for finding the config file.

1. If a user provides the config file as an argument (`--config`), it attempts to use this location
2. Otherwise, it looks in the STL folder (which I imagine was the previous default location)
3. Failing that, it looks one dir above

To facilitate another command-line argument, parsing was moved to `argparse`. This moved everything up one indent, hence the slightly messy commit, apologies.

In conjunction with [PR#175](https://github.com/Rhoban/onshape-to-robot/pull/175) this fixes PureShape functionality in 1.7.7.