### PR TITLE
Add camera support for MuJoCo exporter

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -28,9 +28,9 @@ Specifying degrees of freedom
 
 To create a degree of freedom, you should use the ``dof_`` prefix when placing a mate connector.
 
-* If the mate is **cylindrical** or **revolute**, a ``revolute`` joint will be issued 
-* If the mate is a **slider**, a ``prismatic`` joint will be issued
-* If the mate is **fastened**, a ``fixed`` joint will be issued
+* If the mate connector is **cylindrical** or **revolute**, a ``revolute`` joint will be issued 
+* If the mate connector is a **slider**, a ``prismatic`` joint will be issued
+* If the mate connector is **fastened**, a ``fixed`` joint will be issued
 
 .. note::
 

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -28,9 +28,9 @@ Specifying degrees of freedom
 
 To create a degree of freedom, you should use the ``dof_`` prefix when placing a mate connector.
 
-* If the mate connector is **cylindrical** or **revolute**, a ``revolute`` joint will be issued 
-* If the mate connector is a **slider**, a ``prismatic`` joint will be issued
-* If the mate connector is **fastened**, a ``fixed`` joint will be issued
+* If the mate is **cylindrical** or **revolute**, a ``revolute`` joint will be issued 
+* If the mate is a **slider**, a ``prismatic`` joint will be issued
+* If the mate is **fastened**, a ``fixed`` joint will be issued
 
 .. note::
 

--- a/docs/source/exporter_mujoco.rst
+++ b/docs/source/exporter_mujoco.rst
@@ -9,7 +9,7 @@ Introduction
 MuJoCo is a standard physics simulator, coming with an extensive description format.
 
 * Frames will be added as ``site`` tags in the MuJoCo XML file.
-* *Cameras* can be added by mapping frame names to camera names in the configuration (see :ref:`Cameras <cameras>` section below).
+* *Cameras* can be added by mapping frame names to camera names in the configuration (see :ref:`processor-convert-to-cameras`).
 * *Actuators* will be created for all actuated joints (see below).
 * When :ref:`kinematic loops <kinematic-loops>` are present, they will be enforced using equality constraints.
 
@@ -106,51 +106,7 @@ If you want to include additional XML in the URDF, you can specify the path to t
 
 .. _cameras:
 
-``cameras`` *(default: {})*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``cameras``
+~~~~~~~~~~~
 
-Camera support allows you to add camera elements to your MuJoCo model. Frames are automatically converted to cameras using the built-in ``ProcessorConvertToCameras`` processor.
-
-To add cameras to your robot:
-
-1. Define camera frame references in your Onshape assembly using mate connectors
-2. Configure camera mappings in ``config.json``
-
-.. important::
-
-    **Camera Frame Orientation in MuJoCo**
-
-    When creating mate connectors in Onshape for cameras, ensure the frame orientation follows MuJoCo's camera convention:
-
-    * The camera looks along the **-Z axis** (negative Z direction)
-    * The **+X axis** points to the right
-    * The **+Y axis** points up
-
-    This means your mate connector's Z-axis should point **into** the camera (opposite of the viewing direction).
-
-Example ``config.json`` entry:
-
-.. code-block:: javascript
-
-    {
-        "cameras": {
-            "wrist_camera": "wrist_camera_frame",
-            "head_camera": "head_camera_frame"
-        }
-    }
-
-The keys are the camera names that will appear in the MuJoCo XML, and the values are the frame names defined in your Onshape assembly.
-
-Generated MuJoCo XML
-~~~~~~~~~~~~~~~~~~~~
-
-Cameras will be exported as ``<camera>`` elements within the appropriate body tags:
-
-.. code-block:: xml
-
-    <body name="wrist_link" ...>
-        <!-- ... body content ... -->
-
-        <!-- Camera wrist_camera -->
-        <camera name="wrist_camera" pos="0 0.04 0" quat="0 0 1 0" fovy="45" mode="fixed" resolution="640 480" />
-    </body>
+See :ref:`processor-convert-to-cameras` in the Processors section.

--- a/docs/source/exporter_mujoco.rst
+++ b/docs/source/exporter_mujoco.rst
@@ -9,6 +9,7 @@ Introduction
 MuJoCo is a standard physics simulator, coming with an extensive description format.
 
 * Frames will be added as ``site`` tags in the MuJoCo XML file.
+* *Cameras* can be added using custom processors (see :ref:`Cameras <cameras>` section below).
 * *Actuators* will be created for all actuated joints (see below).
 * When :ref:`kinematic loops <kinematic-loops>` are present, they will be enforced using equality constraints.
 
@@ -102,3 +103,113 @@ If you want to include additional XML in the URDF, you can specify the path to t
 .. note::
 
     Alternatively, ``additional_xml`` can be a list of files
+
+.. _cameras:
+
+Cameras
+-------
+
+Camera support allows you to add camera elements to your MuJoCo model. Cameras are typically added through custom processors that convert frame references to camera elements.
+
+Basic camera usage
+~~~~~~~~~~~~~~~~~~
+
+To add cameras to your robot, you need to:
+
+1. Define camera frame references in your Onshape assembly using mate connectors
+2. Configure camera mappings in ``config.json``
+3. Use a custom processor to convert frames to cameras
+
+.. important::
+
+    **Camera Frame Orientation in MuJoCo**
+
+    When creating mate connectors in Onshape for cameras, ensure the frame orientation follows MuJoCo's camera convention:
+
+    * The camera looks along the **-Z axis** (negative Z direction)
+    * The **+X axis** points to the right
+    * The **+Y axis** points up
+
+    This means your mate connector's Z-axis should point **into** the camera (opposite of the viewing direction).
+
+Example ``config.json`` entry:
+
+.. code-block:: javascript
+
+    {
+        "cameras": {
+            "wrist_camera": "wrist_camera_frame",
+            "head_camera": "head_camera_frame"
+        },
+        "processors": [
+            "my_processors.convert_to_cameras:ProcessorConvertToCameras",
+            // ... other processors
+        ]
+    }
+
+Camera processor example
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Here's an example processor that converts frames to cameras:
+
+.. code-block:: python
+
+    from onshape_to_robot.processor import Processor
+    from onshape_to_robot.config import Config
+    from onshape_to_robot.robot import Robot, Camera
+
+    class ProcessorConvertToCameras(Processor):
+        """Convert frames to camera elements."""
+
+        def __init__(self, config: Config):
+            super().__init__(config)
+            self.cameras = config.get("cameras", {})
+
+        def process(self, robot: Robot):
+            for camera_name, frame_name in self.cameras.items():
+                for link in robot.links:
+                    if frame_name in link.frames:
+                        print(f"Creating camera '{camera_name}' from frame '{frame_name}'")
+                        robot.cameras.append(
+                            Camera(camera_name, link.name, link.frames.pop(frame_name))
+                        )
+                        break
+
+Camera properties
+~~~~~~~~~~~~~~~~~
+
+The ``Camera`` class supports the following optional properties:
+
+* ``fovy`` *(default: 45.0)*: Vertical field of view in degrees
+* ``mode`` *(default: "fixed")*: Camera mode (``fixed``, ``track``, etc.)
+* ``resolution`` *(default: (640, 480))*: Image resolution as a tuple
+
+Example with custom properties:
+
+.. code-block:: python
+
+    from onshape_to_robot.robot import Camera
+
+    camera = Camera(
+        name="my_camera",
+        link_name="head_link",
+        T_link_camera=transform_matrix,
+        fovy=60.0,
+        mode="fixed",
+        resolution=(1280, 720)
+    )
+    robot.cameras.append(camera)
+
+Generated MuJoCo XML
+~~~~~~~~~~~~~~~~~~~~
+
+Cameras will be exported as ``<camera>`` elements within the appropriate body tags:
+
+.. code-block:: xml
+
+    <body name="wrist_link" ...>
+        <!-- ... body content ... -->
+
+        <!-- Camera wrist_camera -->
+        <camera name="wrist_camera" pos="0 0.04 0" quat="0 0 1 0" fovy="45" mode="fixed" resolution="640 480" />
+    </body>

--- a/docs/source/processor_convert_to_cameras.rst
+++ b/docs/source/processor_convert_to_cameras.rst
@@ -21,15 +21,31 @@ Frames are automatically matched to camera names using the ``cameras`` configura
         // ...
 
         "cameras": {
+            // Simple form: just a frame name (uses defaults)
             "wrist_camera": "wrist_camera_frame",
-            "head_camera": "head_camera_frame"
+
+            // Extended form: configure camera properties
+            "head_camera": {
+                "frame": "head_camera_frame",
+                "fovy": 60,
+                "mode": "fixed",
+                "resolution": [1280, 720]
+            }
         }
     }
 
 ``cameras`` *(default: {})*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Maps camera names to frame names defined in your Onshape assembly. The keys are the camera names that will appear in the MuJoCo XML, and the values are the corresponding frame names.
+Maps camera names to frame names defined in your Onshape assembly. The keys are the camera names that will appear in the MuJoCo XML. The values can be either:
+
+* A **string**: the frame name (all camera properties use defaults)
+* A **dict** with the following keys:
+
+  * ``frame`` *(required)*: the frame name in your Onshape assembly
+  * ``fovy`` *(default: 45)*: vertical field of view in degrees
+  * ``mode`` *(default: "fixed")*: MuJoCo camera mode
+  * ``resolution`` *(default: [640, 480])*: image resolution as ``[width, height]``
 
 To add cameras to your robot:
 

--- a/docs/source/processor_convert_to_cameras.rst
+++ b/docs/source/processor_convert_to_cameras.rst
@@ -1,0 +1,63 @@
+.. _processor-convert-to-cameras:
+
+Convert to Cameras
+==================
+
+Introduction
+------------
+
+This processor converts frames to camera elements in your MuJoCo model. It is enabled by default via the ``ProcessorConvertToCameras`` processor.
+
+Frames are automatically matched to camera names using the ``cameras`` configuration entry, and the resulting ``<camera>`` elements are added to the appropriate body tags in the MuJoCo XML output.
+
+``config.json`` entries
+-----------------------
+
+.. code-block:: javascript
+
+    {
+        // ...
+        // General import options (see config.json documentation)
+        // ...
+
+        "cameras": {
+            "wrist_camera": "wrist_camera_frame",
+            "head_camera": "head_camera_frame"
+        }
+    }
+
+``cameras`` *(default: {})*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Maps camera names to frame names defined in your Onshape assembly. The keys are the camera names that will appear in the MuJoCo XML, and the values are the corresponding frame names.
+
+To add cameras to your robot:
+
+1. Define camera frame references in your Onshape assembly using mate connectors
+2. Configure camera mappings in ``config.json``
+
+.. important::
+
+    **Camera Frame Orientation in MuJoCo**
+
+    When creating mate connectors in Onshape for cameras, ensure the frame orientation follows MuJoCo's camera convention:
+
+    * The camera looks along the **-Z axis** (negative Z direction)
+    * The **+X axis** points to the right
+    * The **+Y axis** points up
+
+    This means your mate connector's Z-axis should point **into** the camera (opposite of the viewing direction).
+
+Generated MuJoCo XML
+~~~~~~~~~~~~~~~~~~~~~
+
+Cameras will be exported as ``<camera>`` elements within the appropriate body tags:
+
+.. code-block:: xml
+
+    <body name="wrist_link" ...>
+        <!-- ... body content ... -->
+
+        <!-- Camera wrist_camera -->
+        <camera name="wrist_camera" pos="0 0.04 0" quat="0 0 1 0" fovy="45" mode="fixed" resolution="640 480" />
+    </body>

--- a/docs/source/processors.rst
+++ b/docs/source/processors.rst
@@ -26,4 +26,5 @@ Here is an overview of ``onshape-to-robot`` pipeline:
    processor_collision_as_visual
    processor_convex_decomposition
    processor_fixed_links
+   processor_convert_to_cameras
    custom_processors

--- a/onshape_to_robot/exporter_mujoco.py
+++ b/onshape_to_robot/exporter_mujoco.py
@@ -332,8 +332,11 @@ class ExporterMuJoCo(Exporter):
         """
         self.append(f"<!-- Camera {camera.name} -->")
 
+        # Convert from world frame to link-relative frame
+        T_link_camera = np.linalg.inv(T_world_link) @ camera.T_link_camera
+
         camera_xml: str = f'<camera name="{camera.name}" '
-        camera_xml += self.pos_quat(camera.T_link_camera) + " "
+        camera_xml += self.pos_quat(T_link_camera) + " "
         camera_xml += f'fovy="{camera.fovy}" '
         camera_xml += f'mode="{camera.mode}" '
         camera_xml += f'resolution="{camera.resolution[0]} {camera.resolution[1]}" '

--- a/onshape_to_robot/exporter_mujoco.py
+++ b/onshape_to_robot/exporter_mujoco.py
@@ -3,7 +3,7 @@ import numpy as np
 import os
 import fnmatch
 from .message import success, warning, info
-from .robot import Robot, Link, Part, Joint, Closure
+from .robot import Robot, Link, Part, Joint, Closure, Camera
 from .config import Config
 from .geometry import Box, Cylinder, Sphere, Mesh, Shape
 from .exporter import Exporter
@@ -326,6 +326,21 @@ class ExporterMuJoCo(Exporter):
         site += " />"
         self.append(site)
 
+    def add_camera(self, camera: Camera, T_world_link: np.ndarray):
+        """
+        Add a camera element to the body
+        """
+        self.append(f"<!-- Camera {camera.name} -->")
+
+        camera_xml: str = f'<camera name="{camera.name}" '
+        camera_xml += self.pos_quat(camera.T_link_camera) + " "
+        camera_xml += f'fovy="{camera.fovy}" '
+        camera_xml += f'mode="{camera.mode}" '
+        camera_xml += f'resolution="{camera.resolution[0]} {camera.resolution[1]}" '
+        camera_xml += " />"
+
+        self.append(camera_xml)
+
     def add_link(
         self,
         robot: Robot,
@@ -368,6 +383,11 @@ class ExporterMuJoCo(Exporter):
         # Adding frames attached to current link
         for frame, T_world_frame in link.frames.items():
             self.add_frame(frame, T_world_link, T_world_frame, group=3)
+
+        # Adding cameras attached to current link
+        for camera in robot.cameras:
+            if camera.link_name == link.name:
+                self.add_camera(camera, T_world_link)
 
         # Adding joints and children links
         for joint in robot.get_link_joints(link):

--- a/onshape_to_robot/processor_convert_to_cameras.py
+++ b/onshape_to_robot/processor_convert_to_cameras.py
@@ -1,0 +1,22 @@
+from .processor import Processor
+from .config import Config
+from .robot import Robot, Camera
+from .message import info
+
+class ProcessorConvertToCameras(Processor):
+   """Convert frames to camera elements.
+   Config: "cameras": {"camera_name": "frame_name", ...}
+   Each entry maps a camera name to a frame name on a link.
+   """
+
+  def __init__(self, config: Config):
+    super().__init__(config)
+    self.cameras = config.get("cameras", {})
+
+  def process(self, robot: Robot):
+    for camera_name, frame_name in self.cameras.items():
+      for link in robot.links:
+        if frame_name in link.frames:
+          print(f"  Creating camera '{camera_name}' from frame '{frame_name}' on link '{link.name}'")
+          robot.cameras.append(Camera(camera_name, link.name, link.frames.pop(frame_name)))
+          break

--- a/onshape_to_robot/processor_convert_to_cameras.py
+++ b/onshape_to_robot/processor_convert_to_cameras.py
@@ -17,6 +17,6 @@ class ProcessorConvertToCameras(Processor):
     for camera_name, frame_name in self.cameras.items():
       for link in robot.links:
         if frame_name in link.frames:
-          print(f"  Creating camera '{camera_name}' from frame '{frame_name}' on link '{link.name}'")
+          print(info(f"Creating camera '{camera_name}' from frame '{frame_name}' on link '{link.name}'"))
           robot.cameras.append(Camera(camera_name, link.name, link.frames.pop(frame_name)))
           break

--- a/onshape_to_robot/processor_convert_to_cameras.py
+++ b/onshape_to_robot/processor_convert_to_cameras.py
@@ -6,6 +6,7 @@ from .message import info
 class ProcessorConvertToCameras(Processor):
    """Convert frames to camera elements.
    Config: "cameras": {"camera_name": "frame_name", ...}
+   or: "cameras": {"camera_name": {"frame": "frame_name", "fovy": 60, ...}, ...}
    Each entry maps a camera name to a frame name on a link.
    """
 
@@ -14,9 +15,24 @@ class ProcessorConvertToCameras(Processor):
     self.cameras = config.get("cameras", {})
 
   def process(self, robot: Robot):
-    for camera_name, frame_name in self.cameras.items():
+    for camera_name, camera_config in self.cameras.items():
+      if isinstance(camera_config, str):
+        frame_name = camera_config
+        camera_kwargs = {}
+      elif isinstance(camera_config, dict):
+        frame_name = camera_config["frame"]
+        camera_kwargs = {}
+        if "fovy" in camera_config:
+          camera_kwargs["fovy"] = camera_config["fovy"]
+        if "mode" in camera_config:
+          camera_kwargs["mode"] = camera_config["mode"]
+        if "resolution" in camera_config:
+          camera_kwargs["resolution"] = tuple(camera_config["resolution"])
+      else:
+        continue
+
       for link in robot.links:
         if frame_name in link.frames:
           print(info(f"Creating camera '{camera_name}' from frame '{frame_name}' on link '{link.name}'"))
-          robot.cameras.append(Camera(camera_name, link.name, link.frames.pop(frame_name)))
+          robot.cameras.append(Camera(camera_name, link.name, link.frames.pop(frame_name), **camera_kwargs))
           break

--- a/onshape_to_robot/processors.py
+++ b/onshape_to_robot/processors.py
@@ -7,6 +7,7 @@ from .processor_convex_decomposition import ProcessorConvexDecomposition
 from .processor_collision_as_visual import ProcessorCollisionAsVisual
 from .processor_no_collision_meshes import ProcessorNoCollisionMeshes
 from .processor_ball_to_euler import ProcessorBallToEuler
+from .processor_convert_to_cameras import ProcessorConvertToCameras
 
 default_processors = [
     ProcessorBallToEuler,
@@ -18,4 +19,5 @@ default_processors = [
     ProcessorConvexDecomposition,
     ProcessorNoCollisionMeshes,
     ProcessorCollisionAsVisual,
+    ProcessorConvertToCameras
 ]

--- a/onshape_to_robot/robot.py
+++ b/onshape_to_robot/robot.py
@@ -141,6 +141,28 @@ class Closure:
         self.frame2: str = frame2
 
 
+class Camera:
+    """
+    A camera attached to a link.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        link_name: str,
+        T_link_camera: np.ndarray,
+        fovy: float = 45.0,
+        mode: str = "fixed",
+        resolution: tuple[int, int] = (640, 480),
+    ):
+        self.name: str = name
+        self.link_name: str = link_name
+        self.T_link_camera: np.ndarray = T_link_camera
+        self.fovy: float = fovy
+        self.mode: str = mode
+        self.resolution: tuple[int, int] = resolution
+
+
 class Robot:
     """
     Robot representation produced after requesting Onshape API, and before
@@ -153,6 +175,7 @@ class Robot:
         self.base_links: list[Link] = []
         self.joints: list[Joint] = []
         self.closures: list[Closure] = []
+        self.cameras: list[Camera] = []
 
     def get_link(self, name: str):
         for link in self.links:


### PR DESCRIPTION
This PR adds camera support to the MuJoCo exporter, allowing cameras to be defined in Onshape assemblies and exported to MuJoCo XML format.

## Changes

- Added a `camera` class to robot model with support for fovy, mode, and resolution parameters
- Implemented camera export functionality in MuJoCo exporter
- Added documentation including frame orientation conventions and processor examples
- Minor fix: corrected wording in design.rst (mate connector -> mate)

## Usage

Cameras can be added by: 
1. Defining mate connectors for camera frames in Onshape
2. Mapping them in `config.json` under the `cameras` key
3. Using a custom processor to convert frames to Camera objects

See the updated documentation in `docs/source/exporter_mujoco.rst` for complete examples.

## TODOs

- Add warnings if camera frames don't follow MuJoCo's orientation convention (-Z viewing direction)
- Try and extend support to URDF and SDF formats
- Add an image to exporter_mujoco.rst showing how to orient mate connectors in Onshape. See [link](https://mujoco.readthedocs.io/en/stable/XMLreference.html#body-camera:~:text=The%20camera%20is%20looking%20along%20the%20%2DZ%20axis%20of%20its%20frame.%20The%20%2BX%20axis%20points%20to%20the%20right%2C%20and%20the%20%2BY%20axis%20points%20up.%20Thus%20the%20frame%20position%20and%20orientation%20are%20the%20key%20adjustments%20that%20need%20to%20be%20made%20here.)