### PR TITLE
Adding round_decimals configuration (see #179)

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -85,7 +85,10 @@ Here is an example of complete ``config.json`` file, with details below:
         // Custom processors
         "processors": [
             "my_project.my_custom_processor:MyCustomProcessor"
-        ]
+        ],
+
+        // Number of decimals to round numerical values (default: 12)
+        "round_decimals": 12
 
         // More options available in specific exporters (URDF, SDF, MuJoCo)
         // More options available in processors
@@ -267,3 +270,8 @@ some processing scripts are run everytime you run onshape-to-robot.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 See :ref:`custom processors <custom_processors>` for more information.
+
+``round_decimals`` *(default: 12)*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Numbers displayed in export will be rounded up using `round()` method. The number of decimals that are kept can be controlled using this parameters.

--- a/onshape_to_robot/config.py
+++ b/onshape_to_robot/config.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
-from sys import exit
+import numpy as np
 import re
 import os
 import commentjson as json
-from .message import error, bright, info
 
 
 class Config:
@@ -160,6 +159,9 @@ class Config:
             "include_configuration_suffix", True
         )
 
+        # Number of decimals to keep for small numbers
+        self.round_decimals = self.get("round_decimals", 12)
+
         # Loading processors
         from . import processors
 
@@ -185,3 +187,15 @@ class Config:
                     raise Exception(f"ERROR: Processor {entry} not found")
 
                 self.processors.append(processor(self))
+
+    def round(self, object: float | list | tuple | np.ndarray):
+        """
+        Round the given number or list of numbers using the configuration decimals
+        """
+        if isinstance(object, float):
+            return round(object, self.round_decimals)
+        elif isinstance(object, np.ndarray):
+            return object.round(self.round_decimals)
+        else:
+            original_type = type(object)
+            return original_type(np.array(object).round(self.round_decimals))

--- a/onshape_to_robot/exporter_mujoco.py
+++ b/onshape_to_robot/exporter_mujoco.py
@@ -79,7 +79,7 @@ class ExporterMuJoCo(Exporter):
         for mesh_file in set(self.meshes):
             self.append(f'<mesh file="{mesh_file}" />')
         for material_name, color in self.materials.items():
-            color_str = "%g %g %g %g" % tuple(color)
+            color_str = "%g %g %g %g" % self.config.round(tuple(color))
             self.append(f'<material name="{material_name}" rgba="{color_str}" />')
         self.append("</asset>")
 
@@ -109,9 +109,7 @@ class ExporterMuJoCo(Exporter):
             ):
                 type = joint.properties.get("type", "position")
                 actuator_class = joint.properties.get("class", self.default_class)
-                actuator: str = (
-                    f'<{type} class="{actuator_class}" name="{joint.name}" joint="{joint.name}" '
-                )
+                actuator: str = f'<{type} class="{actuator_class}" name="{joint.name}" joint="{joint.name}" '
 
                 for key in "kp", "kv", "dampratio":
                     if key in joint.properties:
@@ -191,15 +189,17 @@ class ExporterMuJoCo(Exporter):
         # Populating body inertial properties
         # https://mujoco.readthedocs.io/en/stable/XMLreference.html#body-inertial
         inertial: str = "<inertial "
-        inertial += 'pos="%g %g %g" ' % tuple(com)
-        inertial += 'mass="%g" ' % mass
-        inertial += 'fullinertia="%g %g %g %g %g %g" ' % (
-            inertia[0, 0],
-            inertia[1, 1],
-            inertia[2, 2],
-            inertia[0, 1],
-            inertia[0, 2],
-            inertia[1, 2],
+        inertial += 'pos="%g %g %g" ' % self.config.round(tuple(com))
+        inertial += 'mass="%g" ' % self.config.round(mass)
+        inertial += 'fullinertia="%g %g %g %g %g %g" ' % self.config.round(
+            (
+                inertia[0, 0],
+                inertia[1, 1],
+                inertia[2, 2],
+                inertia[0, 1],
+                inertia[0, 2],
+                inertia[1, 2],
+            )
         )
         inertial += " />"
         self.append(inertial)
@@ -243,14 +243,14 @@ class ExporterMuJoCo(Exporter):
         geom += self.pos_quat(T_link_shape) + " "
 
         if isinstance(shape, Box):
-            geom += 'type="box" size="%g %g %g" ' % tuple(shape.size / 2)
+            geom += 'type="box" size="%g %g %g" ' % self.config.round(tuple(shape.size / 2))
         elif isinstance(shape, Cylinder):
             geom += 'type="cylinder" size="%g %g" ' % (
                 shape.radius,
                 shape.length / 2,
             )
         elif isinstance(shape, Sphere):
-            geom += 'type="sphere" size="%g" ' % shape.radius
+            geom += 'type="sphere" size="%g" ' % self.config.round(shape.radius)
 
         if class_ == "visual":
             material_name = f"{part.name}_material"
@@ -283,7 +283,7 @@ class ExporterMuJoCo(Exporter):
             return
 
         joint_xml: str = "<joint "
-        joint_xml += 'axis="%g %g %g" ' % tuple(joint.axis)
+        joint_xml += 'axis="%g %g %g" ' % self.config.round(tuple(joint.axis))
         joint_xml += f'name="{joint.name}" '
         if joint.joint_type == Joint.REVOLUTE:
             joint_xml += 'type="hinge" '
@@ -381,7 +381,7 @@ class ExporterMuJoCo(Exporter):
         """
         pos = matrix[:3, 3]
         quat = mat2quat(matrix[:3, :3])
-        xml = 'pos="%g %g %g" quat="%g %g %g %g"' % (*pos, *quat)
+        xml = 'pos="%g %g %g" quat="%g %g %g %g"' % self.config.round((*pos, *quat))
 
         return xml
 

--- a/onshape_to_robot/exporter_sdf.py
+++ b/onshape_to_robot/exporter_sdf.py
@@ -83,30 +83,30 @@ class ExporterSDF(Exporter):
         self.append("<inertial>")
         self.append(
             '<pose>%g %g %g 0 0 0</pose>'
-            % (
+            % self.config.round((
                 com[0],
                 com[1],
                 com[2],
-            )
+            ))
         )
-        self.append("<mass>%g</mass>" % mass)
+        self.append("<mass>%g</mass>" % self.config.round(mass))
         self.append(
             "<inertia><ixx>%g</ixx><ixy>%g</ixy><ixz>%g</ixz><iyy>%g</iyy><iyz>%g</iyz><izz>%g</izz></inertia>"
-            % (
+            % self.config.round((
                 inertia[0, 0],
                 inertia[0, 1],
                 inertia[0, 2],
                 inertia[1, 1],
                 inertia[1, 2],
                 inertia[2, 2],
-            )
+            ))
         )
         self.append("</inertial>")
 
     def append_material(self, color: np.ndarray):
         self.append(f"<material>")
-        self.append("<ambient>%g %g %g %g</ambient>" % (color[0], color[1], color[2], color[3]))
-        self.append("<diffuse>%g %g %g %g</diffuse>" % (color[0], color[1], color[2], color[3]))
+        self.append("<ambient>%g %g %g %g</ambient>" % self.config.round((color[0], color[1], color[2], color[3])))
+        self.append("<diffuse>%g %g %g %g</diffuse>" % self.config.round((color[0], color[1], color[2], color[3])))
         self.append("<specular>0.1 0.1 0.1 1</specular>")
         self.append("<emissive>0 0 0 0</emissive>")
         self.append("</material>")
@@ -162,14 +162,14 @@ class ExporterSDF(Exporter):
 
         self.append("<geometry>")
         if isinstance(shape, Box):
-            self.append("<box><size>%g %g %g</size></box>" % tuple(shape.size))
+            self.append("<box><size>%g %g %g</size></box>" % self.config.round(tuple(shape.size)))
         elif isinstance(shape, Cylinder):
             self.append(
                 "<cylinder><length>%g</length><radius>%g</radius></cylinder>"
-                % (shape.length, shape.radius)
+                % self.config.round((shape.length, shape.radius))
             )
         elif isinstance(shape, Sphere):
-            self.append("<sphere><radius>%g</radius></sphere>" % shape.radius)
+            self.append("<sphere><radius>%g</radius></sphere>" % self.config.round((shape.radius,)))
         self.append("</geometry>")
 
         if node == "visual":
@@ -211,18 +211,18 @@ class ExporterSDF(Exporter):
         self.append(f"<parent>{joint.parent.name}</parent>")
         self.append(f"<child>{joint.child.name}</child>")
         self.append("<axis>")
-        self.append("<xyz>%g %g %g</xyz>" % tuple(joint.axis))
+        self.append("<xyz>%g %g %g</xyz>" % self.config.round(tuple(joint.axis)))
 
         self.append("<limit>")
         if "max_effort" in joint.properties:
-            self.append(f"<effort>%g</effort>" % joint.properties["max_effort"])
+            self.append("<effort>%g</effort>" % self.config.round(joint.properties["max_effort"]))
         else:
-            self.append(f"<effort>10</effort>")
+            self.append("<effort>10</effort>")
 
         if "max_velocity" in joint.properties:
-            self.append(f"<velocity>%g</velocity>" % joint.properties["max_velocity"])
+            self.append("<velocity>%g</velocity>" % self.config.round(joint.properties["max_velocity"]))
         else:
-            self.append(f"<velocity>10</velocity>")
+            self.append("<velocity>10</velocity>")
 
         joint_limits = joint.properties.get("limits", joint.limits)
         if joint_limits is None:
@@ -315,7 +315,7 @@ class ExporterSDF(Exporter):
 
         sdf = "<pose%s>%g %g %g %g %g %g</pose>"
 
-        return sdf % (relative, *matrix[:3, 3], *rotation_matrix_to_rpy(matrix))
+        return sdf % self.config.round((relative, *matrix[:3, 3], *rotation_matrix_to_rpy(matrix)))
 
     def write_xml(self, robot: Robot, filename: str) -> str:
         model_config = MODEL_CONFIG_XML % (robot.name, os.path.basename(filename))


### PR DESCRIPTION
Opening a pull request for #179 

@T-K-233 in this PR the parameter `round_decimals` is introduced in `config.json`. I set the default value to 12, which indeed could break some BC but it seems sane to ignore smaller numbers by defaults (which is, if expressing meters, below the size of an atom)