### PR TITLE
Allow geom_properties to override geometry type and remove attributes

### DIFF
--- a/docs/source/exporter_mujoco.rst
+++ b/docs/source/exporter_mujoco.rst
@@ -55,11 +55,24 @@ Here is an example of complete ``config.json`` file, with details below:
 
         // Override geometry properties (default: {})
         "geom_properties": {
-            // Set properties for specific links using pattern matching
+            // Replace mesh collision with capsule geometry at body origin
             "foot": {
                 "collision": {
-                    "name": "left_foot_collision",
+                    "type": "capsule",
+                    "size": "0.005",
+                    "fromto": "0 0 -0.01 0 0 0.01",
+                    "pos": null,
+                    "quat": null,
                     "friction": "1.2 0.005 0.0001"
+                }
+            },
+            "foot_2": {
+                "collision": {
+                    "type": "capsule",
+                    "size": "0.005",
+                    "fromto": "0 0 -0.01 0 0 0.01",
+                    "pos": null,
+                    "quat": null
                 }
             },
             // Wildcard patterns are supported
@@ -117,8 +130,12 @@ Properties can be specified separately for ``visual`` and ``collision`` geometri
 
 Wildcard patterns (``*``, ``?``, ``[seq]``) are supported for matching part names. When multiple patterns match, properties are merged in order with later matches overriding earlier ones.
 
-All properties are added as XML attributes to the ``<geom ...>`` tag. Common MuJoCo geom attributes include:
+All properties are added as XML attributes to the ``<geom ...>`` tag. **Properties specified in the config take priority and will override default values**, including the geometry type.
 
+Common MuJoCo geom attributes include:
+
+* ``type``: Override the geometry type (e.g., ``"capsule"``, ``"box"``, ``"sphere"``, ``"cylinder"``)
+* ``size``: Size parameters for the geometry type (e.g., ``"0.005"`` for capsule radius when using ``fromto``)
 * ``name``: Override the geometry name
 * ``friction``: Friction coefficients (e.g., ``"1.2 0.005 0.0001"``)
 * ``solimp``: Solver impedance parameters (e.g., ``"0.9 0.95 0.001"``)
@@ -126,6 +143,30 @@ All properties are added as XML attributes to the ``<geom ...>`` tag. Common MuJ
 * ``contype``: Contact type bitmask (e.g., ``"1"``)
 * ``conaffinity``: Contact affinity bitmask (e.g., ``"1"``)
 * ``rgba``: Color and transparency (e.g., ``"1 0 0 1"``)
+
+.. note::
+
+    You can replace mesh geometries with primitive shapes (capsule, box, sphere, cylinder) by setting the ``type`` and ``size`` attributes. When the type is overridden, mesh-specific attributes are automatically excluded.
+
+.. note::
+
+    To remove default attributes (such as ``pos`` or ``quat``), set them to ``null`` in the JSON config. For example:
+
+    .. code-block:: javascript
+
+        "geom_properties": {
+            "foot": {
+                "collision": {
+                    "type": "capsule",
+                    "size": "0.005",
+                    "fromto": "0 0 -0.01 0 0 0.01",
+                    "pos": null,
+                    "quat": null
+                }
+            }
+        }
+
+    This is useful when replacing mesh geometries with primitives and you want the geometry at the body origin.
 
 ``equalities`` *(default: {})*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/exporter_mujoco.rst
+++ b/docs/source/exporter_mujoco.rst
@@ -66,14 +66,23 @@ Here is an example of complete ``config.json`` file, with details below:
                     "friction": "1.2 0.005 0.0001"
                 }
             },
+            // Multiple colliders - approximate complex shape with primitives
             "foot_2": {
-                "collision": {
-                    "type": "capsule",
-                    "size": "0.005",
-                    "fromto": "0 0 -0.01 0 0 0.01",
-                    "pos": null,
-                    "quat": null
-                }
+                "collision": [
+                    {
+                        "type": "capsule",
+                        "size": "0.005",
+                        "fromto": "0 0 -0.01 0 0 0",
+                        "pos": null,
+                        "quat": null
+                    },
+                    {
+                        "type": "sphere",
+                        "size": "0.008",
+                        "pos": "0 0 0.01",
+                        "quat": null
+                    }
+                ]
             },
             // Wildcard patterns are supported
             "leg_*": {
@@ -130,6 +139,8 @@ Properties can be specified separately for ``visual`` and ``collision`` geometri
 
 Wildcard patterns (``*``, ``?``, ``[seq]``) are supported for matching part names. When multiple patterns match, properties are merged in order with later matches overriding earlier ones.
 
+**Multiple Colliders:** The ``collision`` property can be an array to define multiple collision geometries for a single part. This is useful for approximating complex mesh shapes with multiple primitives for better physics performance.
+
 All properties are added as XML attributes to the ``<geom ...>`` tag. **Properties specified in the config take priority and will override default values**, including the geometry type.
 
 Common MuJoCo geom attributes include:
@@ -167,6 +178,36 @@ Common MuJoCo geom attributes include:
         }
 
     This is useful when replacing mesh geometries with primitives and you want the geometry at the body origin.
+
+.. note::
+
+    **Multiple Colliders** - You can approximate complex shapes with multiple primitives by providing an array:
+
+    .. code-block:: javascript
+
+        "geom_properties": {
+            "hand": {
+                "collision": [
+                    {
+                        "type": "box",
+                        "size": "0.02 0.04 0.01",
+                        "pos": "0 0 0"
+                    },
+                    {
+                        "type": "sphere",
+                        "size": "0.015",
+                        "pos": "0 0.02 0"
+                    },
+                    {
+                        "type": "sphere",
+                        "size": "0.015",
+                        "pos": "0 -0.02 0"
+                    }
+                ]
+            }
+        }
+
+    Each array entry generates a separate ``<geom>`` tag, allowing you to build complex collision shapes from primitives. This often provides better simulation performance than mesh collisions.
 
 ``equalities`` *(default: {})*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/onshape_to_robot/robot_builder.py
+++ b/onshape_to_robot/robot_builder.py
@@ -360,10 +360,18 @@ class RobotBuilder:
                             **visual_properties,
                             **pattern_props.get("visual", {}),
                         }
-                        collision_properties = {
-                            **collision_properties,
-                            **pattern_props.get("collision", {}),
-                        }
+
+                        # Handle collision as dict or list
+                        collision_value = pattern_props.get("collision", {})
+                        if isinstance(collision_value, list):
+                            # Multiple colliders - store list directly
+                            collision_properties = collision_value
+                        else:
+                            # Single collider - merge dicts
+                            collision_properties = {
+                                **collision_properties,
+                                **collision_value,
+                            }
                     else:
                         # Apply to both if not nested
                         visual_properties = {**visual_properties, **pattern_props}

--- a/onshape_to_robot/robot_builder.py
+++ b/onshape_to_robot/robot_builder.py
@@ -332,13 +332,14 @@ class RobotBuilder:
 
         # Adding non-ignored meshes
         meshes = []
-        mesh = Mesh(os.path.relpath(stl_file, self.config.output_directory), color)
-        if self.part_is_ignored(part_name, "visual"):
-            mesh.visual = False
-        if self.part_is_ignored(part_name, "collision"):
-            mesh.collision = False
-        if mesh.visual or mesh.collision:
-            meshes.append(mesh)
+        if stl_file is not None:
+            mesh = Mesh(os.path.relpath(stl_file, self.config.output_directory), color)
+            if self.part_is_ignored(part_name, "visual"):
+                mesh.visual = False
+            if self.part_is_ignored(part_name, "collision"):
+                mesh.collision = False
+            if mesh.visual or mesh.collision:
+                meshes.append(mesh)
 
         # Get unique part name (with _2, _3 suffixes for duplicates)
         unique_part_name = self.unique_name(instance, "part")


### PR DESCRIPTION
Enables `geom_properties` config to override default geometry attributes, including type.

### What's new:
- Remove default attributes by setting them to `null`
- Config properties now take priority over defaults

### Example:
```json
{
  "geom_properties": {
    "foot": {
      "collision": {
        "type": "capsule",
        "size": "0.005",
        "fromto": "0 0 -0.01 0 0 0.01",
        "pos": null,
        "quat": null
      }
    }
  }
}
```
This replaces the foot mesh collision with a capsule at the body origin.