### PR TITLE
Using paths relative to config.output_directory for meshes in robot.py, allowing pickle portability (to test)

### DIFF
--- a/onshape_to_robot/exporter_mujoco.py
+++ b/onshape_to_robot/exporter_mujoco.py
@@ -209,7 +209,7 @@ class ExporterMuJoCo(Exporter):
         Add a mesh node (e.g. STL) to the MuJoCo file
         """
         # Retrieving mesh file and material name
-        mesh_file = os.path.relpath(mesh.filename, self.config.asset_path(""))
+        mesh_file = os.path.relpath(self.config.output_directory + "/" + mesh.filename, self.config.asset_path(""))
         mesh_file_no_ext = ".".join(os.path.basename(mesh_file).split(".")[:-1])
         material_name = mesh_file_no_ext + "_material"
 

--- a/onshape_to_robot/exporter_sdf.py
+++ b/onshape_to_robot/exporter_sdf.py
@@ -128,7 +128,7 @@ class ExporterSDF(Exporter):
         T_link_part = np.linalg.inv(T_world_link) @ part.T_world_part
         self.append(self.pose(T_link_part, relative_to=link.name))
 
-        mesh_file = os.path.relpath(mesh.filename, self.config.output_directory)
+        mesh_file = mesh.filename
 
         self.append("<geometry>")
         self.append(

--- a/onshape_to_robot/exporter_urdf.py
+++ b/onshape_to_robot/exporter_urdf.py
@@ -119,7 +119,7 @@ class ExporterURDF(Exporter):
         T_link_part = np.linalg.inv(T_world_link) @ part.T_world_part
         self.append(self.origin(T_link_part))
 
-        mesh_file = os.path.relpath(mesh.filename, self.config.output_directory)
+        mesh_file = mesh.filename
         if self.package_name:
             mesh_file = self.package_name + "/" + mesh_file
 

--- a/onshape_to_robot/processor_convex_decomposition.py
+++ b/onshape_to_robot/processor_convex_decomposition.py
@@ -49,10 +49,14 @@ class ProcessorConvexDecomposition(Processor):
     def process(self, robot: Robot):
         if self.convex_decomposition:
             os.makedirs(self.config.asset_path("convex_decomposition"), exist_ok=True)
+            getcwd = os.getcwd()
+            os.chdir(self.config.output_directory)
 
             for link in robot.links:
                 for part in link.parts:
                     self.convex_decompose(part)
+
+            os.chdir(getcwd)
 
     def convex_decompose(self, part: Part):
         import coacd

--- a/onshape_to_robot/processor_merge_parts.py
+++ b/onshape_to_robot/processor_merge_parts.py
@@ -20,8 +20,11 @@ class ProcessorMergeParts(Processor):
     def process(self, robot: Robot):
         if self.merge_stls:
             os.makedirs(self.config.asset_path("merged"), exist_ok=True)
+            getcwd = os.getcwd()
+            os.chdir(self.config.output_directory)
             for link in robot.links:
                 self.merge_parts(link)
+            os.chdir(getcwd)
 
     def load_mesh(self, stl_file: str) -> mesh.Mesh:
         return mesh.Mesh.from_file(stl_file)
@@ -119,7 +122,7 @@ class ProcessorMergeParts(Processor):
                 )
                 self.save_mesh(visual_mesh, filename)
                 merged_meshes.append(
-                    Mesh(filename, color, visual=True, collision=False)
+                    Mesh(os.path.relpath(filename, self.config.output_directory), color, visual=True, collision=False)
                 )
 
         if self.merge_stls != "visual":
@@ -130,7 +133,7 @@ class ProcessorMergeParts(Processor):
                 )
                 self.save_mesh(collision_mesh, filename)
                 merged_meshes.append(
-                    Mesh(filename, color, visual=False, collision=True)
+                    Mesh(os.path.relpath(filename, self.config.output_directory), color, visual=False, collision=True)
                 )
 
         mass, com, inertia = link.get_dynamics(T_world_com)

--- a/onshape_to_robot/processor_scad.py
+++ b/onshape_to_robot/processor_scad.py
@@ -47,6 +47,8 @@ class ProcessorScad(Processor):
 
     def process(self, robot: Robot):
         if self.use_scads:
+            getcwd = os.getcwd()
+            os.chdir(self.config.output_directory)
             print(info("+ Parsing OpenSCAD files..."))
             for link in robot.links:
                 for part in link.parts:
@@ -61,6 +63,7 @@ class ProcessorScad(Processor):
                     for converted_mesh in converted_meshes:
                         converted_mesh.collision = False
                         part.prune_unused_geometry()
+            os.chdir(getcwd)
 
     def multmatrix_parse(self, parameters: str):
         matrix = np.matrix(json.loads(parameters), dtype=float)

--- a/onshape_to_robot/processor_simplify_stls.py
+++ b/onshape_to_robot/processor_simplify_stls.py
@@ -38,6 +38,9 @@ class ProcessorSimplifySTLs(Processor):
                 self.simplify_stls != "visual" and self.simplify_stls != "collision"
             )
             simplified = set()
+            getcwd = os.getcwd()
+            # Changing directory to output to have relative paths working
+            os.chdir(self.config.output_directory)
             for link in robot.links:
                 for part in link.parts:
                     for mesh in part.meshes:
@@ -46,6 +49,7 @@ class ProcessorSimplifySTLs(Processor):
                         ) and mesh.filename not in simplified:
                             simplified.add(mesh.filename)
                             self.simplify_stl(mesh.filename)
+            os.chdir(getcwd)
 
     def reduce_faces(self, filename: str, reduction: float = 0.9):
         mesh_set = self.pymeshlab.MeshSet()

--- a/onshape_to_robot/robot_builder.py
+++ b/onshape_to_robot/robot_builder.py
@@ -332,7 +332,7 @@ class RobotBuilder:
 
         # Adding non-ignored meshes
         meshes = []
-        mesh = Mesh(stl_file, color)
+        mesh = Mesh(os.path.relpath(stl_file, self.config.output_directory), color)
         if self.part_is_ignored(part_name, "visual"):
             mesh.visual = False
         if self.part_is_ignored(part_name, "collision"):


### PR DESCRIPTION
If a robot.pkl is shared / moved from a computer to another, paths in robot.py should all be relative to the output_directory to ensure it will work again

In this PR, mesh paths are relative to the output directory

Relevant  processors use chdir to the output directory so that the code remains the same

(This has not been tested yet, wip)