### PR TITLE
Skip dof with empty features

### DIFF
--- a/onshape_to_robot/assembly.py
+++ b/onshape_to_robot/assembly.py
@@ -764,14 +764,17 @@ class Assembly:
                     if parameter["message"]["parameterId"] == "matesQuery":
                         queries = parameter["message"]["queries"]
                         if len(queries) == 2:
-                            dof1 = self.get_feature_by_id(
+                            dof1_feature = self.get_feature_by_id(
                                 queries[0]["message"]["featureId"]
-                            )["message"]["name"]
-                            dof2 = self.get_feature_by_id(
+                            )
+                            dof2_feature = self.get_feature_by_id(
                                 queries[1]["message"]["featureId"]
-                            )["message"]["name"]
-                            if dof1.startswith("dof_") and dof2.startswith("dof_"):
-                                mated_dofs = [dof1[4:], dof2[4:]]
+                            )
+                            if dof1_feature is not None and dof2_feature is not None:
+                                dof1 = dof1_feature["message"]["name"]
+                                dof2 = dof2_feature["message"]["name"]
+                                if dof1.startswith("dof_") and dof2.startswith("dof_"):
+                                    mated_dofs = [dof1[4:], dof2[4:]]
                     elif parameter["message"]["parameterId"] == "relationRatio":
                         ratio = self.read_expression(parameter["message"]["expression"])
                     elif parameter["message"]["parameterId"] == "reverseDirection":


### PR DESCRIPTION
When exporting from different robot configurations, it is possible that some of the degree of freedoms are silently supressed (indicated by _italic font_ in Onshape).

An example is show below:
<img width="270" height="87" alt="image" src="https://github.com/user-attachments/assets/d76599ef-99a1-410d-ac1f-5502989ee776" />

Since we change to a different configuration, the Gear relation is automatically supressed, but still can be discovered by the export script.
In this case, `Assembly.get_feature_by_id()` will return `None`.

This PR adds additional check for this case, and skip the dof with empty features to avoid Python raising exceptions.

