### PR TITLE
Fix edit-shape helper opening OpenSCAD in wrong directory for relative paths

### DIFF
--- a/onshape_to_robot/edit_shape.py
+++ b/onshape_to_robot/edit_shape.py
@@ -18,7 +18,7 @@ def main():
             scad += "// sphere(10);\n"
             with open(fileName, "w", encoding="utf-8") as stream:
                 stream.write(scad)
-        directory = os.path.dirname(fileName)
+        directory = os.path.dirname(os.path.abspath(fileName))
         os.system("cd " + directory + "; openscad " + os.path.basename(fileName))
 
 


### PR DESCRIPTION
## The problem

When `onshape-to-robot-edit-shape <file>.stl` is run with a relative path (e.g., from inside the project directory), the helper fails to open OpenSCAD on the generated `.scad` file. `os.path.dirname("link_5.scad")` returns `""`, so the shell command actually becomes this: `cd ; openscad link_5.scad`. `cd` with no argument changes to `$HOME`, and OpenSCAD then tries to load `link_5.scad` from there - which does not exist, since the helper just created it in the original cwd. 

## The fix
Resolve the path with `os.path.abspath` before taking the dirname. `directory` is then always the absolute parent folder, regardless of whether the user passed a relative or absolute path.

## Tested with

- `cd /path/to/project && onshape-to-robot-edit-shape link_5.stl`
- onshape-to-robot-edit-shape /abs/path/to/link_5.stl` (This still works)