### PR TITLE
Pass solreffriction and solimpfriction through to joints

### DIFF
--- a/docs/source/exporter_mujoco.rst
+++ b/docs/source/exporter_mujoco.rst
@@ -102,6 +102,8 @@ Possible values are:
     * ``damping``
     * ``armature``
     * ``stiffness``
+    * ``solreffriction``
+    * ``solimpfriction``
 
 * The following are reflected as actuator (``<position ...>`` or other) attributes:
 

--- a/onshape_to_robot/exporter_mujoco.py
+++ b/onshape_to_robot/exporter_mujoco.py
@@ -315,6 +315,8 @@ class ExporterMuJoCo(Exporter):
             "armature",
             "damping",
             "stiffness",
+            "solreffriction",
+            "solimpfriction",
         ):
             if key in joint.properties:
                 joint_xml += f'{key}="{joint.properties[key]}" '


### PR DESCRIPTION
Adds `solreffriction` and `solimpfriction` to the `joint_properties` keys reflected as `<joint ...>` attributes in the MuJoCo exporter, alongside frictionloss, damping, armature and stiffness.

These two attributes control how rigidly MuJoCo enforces the dry friction constraint. With the defaults, a joint that relies on frictionloss to hold a static load creeps, and there was previously no way to set them from config.json. Docs updated accordingly.