### PR TITLE
fix: correctly detect surface parts with no dynamics

### DIFF
--- a/onshape_to_robot/robot_builder.py
+++ b/onshape_to_robot/robot_builder.py
@@ -261,17 +261,22 @@ class RobotBuilder:
                     partid=instance["partId"],
                 )
 
-            if instance["partId"] not in mass_properties["bodies"]:
+            body = mass_properties["bodies"].get(instance["partId"])
+
+            # Surfaces (sheet bodies) have no volume and thus no dynamics. Onshape
+            # reports them with "hasMass": false (and may omit them from "bodies"
+            # entirely), so relying on presence in "bodies" alone misses them.
+            if body is None or not body.get("hasMass", True):
                 print(
                     warning(
                         f"WARNING: part {instance['name']} has no dynamics (maybe it is a surface)"
                     )
                 )
-                return
-            mass_properties = mass_properties["bodies"][instance["partId"]]
-            mass = mass_properties["mass"][0]
-            com = mass_properties["centroid"]
-            inertia = mass_properties["inertia"]
+                return 0.0, np.zeros(3), np.zeros((3, 3))
+
+            mass = body["mass"][0]
+            com = body["centroid"]
+            inertia = body["inertia"]
 
             if abs(mass) < 1e-9:
                 print(


### PR DESCRIPTION
## Problem

In `RobotBuilder.get_dynamics`, surface (sheet body) parts were not handled correctly:

```python
if instance["partId"] not in mass_properties["bodies"]:
    print(warning(f"WARNING: part {instance['name']} has no dynamics (maybe it is a surface)"))
    return
```

Two issues:

1. **Detection was wrong.** For an actual surface, the Onshape mass properties API still includes the `partId` in `"bodies"` — just with `"hasMass": false` and zero mass. So `partId not in bodies` never fires for a real surface; it falls through and instead crashes at `mass = mass_properties["mass"][0]` because `mass` field does not exist in `mass_properties`.
2. **It crashed.** The bare `return` yields `None`, but the sole caller unpacks the result (`mass, com, inertia = self.get_dynamics(instance)`), raising `TypeError: cannot unpack non-iterable NoneType object`.

## Fix

Detect surfaces via the documented per-body `hasMass` field (still handling an absent body defensively), and return zeroed dynamics so the part is imported with its meshes but contributes no mass or inertia:

```python
body = mass_properties["bodies"].get(instance["partId"])

if body is None or not body.get("hasMass", True):
    print(warning(f"WARNING: part {instance['name']} has no dynamics (maybe it is a surface)"))
    return 0.0, np.zeros(3), np.zeros((3, 3))
```

A genuinely zero-mass **solid** (no material assigned) still falls through to the separate "assign a material" warning, as before.

## Testing

Verified against an assembly containing a surface part: the "maybe it is a surface" warning now fires (instead of the material warning), and the part imports with zero mass instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)