### PR TITLE
Fix mate discovery and body identity for nested, independently-articulable sub-assemblies

### DIFF
--- a/onshape_to_robot/assembly.py
+++ b/onshape_to_robot/assembly.py
@@ -100,11 +100,18 @@ class Assembly:
         self.link_names: dict[int, str] = {}
         # Relation indexed by target joints, values are [source joint, ratio]
         self.relations: dict = {}
+        # Maps a pattern-generated instance id to the seed instance id it was
+        # patterned from, so patterned copies (which have no mate of their
+        # own -- only a geometric transform) can inherit their seed's body
+        # membership for connectivity purposes, while still using their own
+        # real position for geometry.
+        self.pattern_seed_of: dict[str, str] = {}
 
         self.ensure_workspace_or_version()
         self.find_assembly()
         self.check_configuration()
         self.retrieve_assembly()
+        self.load_patterns()
         self.find_instances()
         self.load_features()
         self.load_configuration()
@@ -266,6 +273,36 @@ class Assembly:
         self.occurrences: dict = {}
         for occurrence in self.assembly_data["rootAssembly"]["occurrences"]:
             self.occurrences[tuple(occurrence["path"])] = occurrence
+
+    def load_patterns(self):
+        """
+        Build a pattern-copy -> seed instance id map from every "patterns"
+        list in the document (top-level assembly and every sub-assembly), so
+        patterned instances can inherit their seed's body membership.
+        """
+        assemblies = [self.assembly_data["rootAssembly"]] + self.assembly_data[
+            "subAssemblies"
+        ]
+        for assembly_like in assemblies:
+            for pattern in assembly_like.get("patterns", []):
+                if pattern.get("suppressed"):
+                    continue
+                for seed_id, copy_ids in pattern.get(
+                    "seedToPatternInstances", {}
+                ).items():
+                    for copy_id in copy_ids:
+                        self.pattern_seed_of[copy_id] = seed_id
+
+    def canonicalize_occurrence(self, path: list) -> tuple:
+        """
+        Replace any pattern-generated instance id in an occurrence path with
+        its seed instance id, so a patterned copy resolves to the same body
+        as the instance it was patterned from (a rigid pattern replicates a
+        rigid relationship, not an independently-connected new part).
+        Geometry/transform lookups must keep using the real, un-substituted
+        path -- only body-membership resolution should use this.
+        """
+        return tuple(self.pattern_seed_of.get(part, part) for part in path)
 
     def find_instances(self, prefix: list = [], instances=None):
         """
@@ -438,9 +475,11 @@ class Assembly:
         registered ancestor. This lets occurrences never individually
         merged/mated (e.g. unmated fasteners nested inside a sub-assembly)
         inherit the body of whichever ancestor occurrence they belong to,
-        instead of only ever matching a bare top-level instance id.
+        instead of only ever matching a bare top-level instance id. Pattern
+        copies are canonicalized to their seed id first, so a copy resolves
+        to the same body as whatever its seed is connected to.
         """
-        path = tuple(path)
+        path = self.canonicalize_occurrence(path)
         for length in range(len(path), 0, -1):
             key = path[:length]
             if key in self.instance_body:
@@ -462,7 +501,7 @@ class Assembly:
         Pre-assign all top-level instances to a separate body id
         """
         top_level_instances = self.assembly_data["rootAssembly"]["instances"]
-        self.make_body((top_level_instances[0]["id"],))
+        self.make_body(self.canonicalize_occurrence([top_level_instances[0]["id"]]))
 
         # We first search for DOFs
         for prefix, data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
@@ -598,8 +637,9 @@ class Assembly:
 
         # Checking that all intances are assigned to a body
         for instance in self.assembly_data["rootAssembly"]["instances"]:
-            if (instance["id"],) not in self.instance_body and not instance["suppressed"]:
-                self.make_body((instance["id"],))
+            canonical = self.canonicalize_occurrence([instance["id"]])
+            if canonical not in self.instance_body and not instance["suppressed"]:
+                self.make_body(canonical)
 
         # Processing loop closing frames
         for prefix, data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
@@ -818,8 +858,12 @@ class Assembly:
                 ):
                     continue
 
-                occurrence_A = tuple(prefix + data["matedEntities"][0]["matedOccurrence"])
-                occurrence_B = tuple(prefix + data["matedEntities"][1]["matedOccurrence"])
+                occurrence_A = self.canonicalize_occurrence(
+                    prefix + data["matedEntities"][0]["matedOccurrence"]
+                )
+                occurrence_B = self.canonicalize_occurrence(
+                    prefix + data["matedEntities"][1]["matedOccurrence"]
+                )
 
                 yield prefix, data, occurrence_A, occurrence_B
 
@@ -835,7 +879,9 @@ class Assembly:
                 data = feature["featureData"]
 
                 for occurrence in data["occurrences"]:
-                    group.append(tuple(prefix + occurrence["occurrence"]))
+                    group.append(
+                        self.canonicalize_occurrence(prefix + occurrence["occurrence"])
+                    )
             groups.append(group)
 
         return groups

--- a/onshape_to_robot/assembly.py
+++ b/onshape_to_robot/assembly.py
@@ -34,6 +34,7 @@ class DOF:
         T_world_mate: np.ndarray,
         limits: tuple | None,
         axis: np.ndarray = np.array([0.0, 0.0, 1.0]),
+        prefix: tuple = (),
     ):
         self.body1_id: int = body1_id
         self.body2_id: int = body2_id
@@ -42,6 +43,12 @@ class DOF:
         self.T_world_mate: np.ndarray = T_world_mate
         self.limits: tuple | None = limits
         self.axis: np.ndarray = axis
+        # Occurrence path leading to the sub-assembly instance this DOF was
+        # discovered in (empty at the top level). Needed to correctly pair a
+        # gear/mimic relation with the matching DOFs when the sub-assembly
+        # defining both is itself instanced more than once (e.g. three legs
+        # sharing one leg sub-assembly, each with its own master/follower).
+        self.prefix: tuple = prefix
 
     def flip(self, flip_limits: bool = True):
         if flip_limits and self.limits is not None:
@@ -338,6 +345,12 @@ class Assembly:
         Load features, also fetching the parametric features of every nested
         sub-assembly so mate limits and gear/mimic relations defined inside a
         sub-assembly's own tab (not just the top-level assembly) are found.
+        Kept both as one flat merged list (self.features, used by
+        get_limits()/get_offset(), which only need to find a mate's own
+        properties by name and don't care which physical instance is asking)
+        and indexed per sub-assembly document (self.features_by_key, used by
+        find_relations() to correctly pair a gear/mimic relation with the
+        matching DOFs when a sub-assembly is instanced more than once).
         """
 
         self.features = self.client.get_features(
@@ -348,6 +361,14 @@ class Assembly:
             configuration=self.config.configuration,
         )
 
+        top_key = (
+            self.document_id,
+            self.element_id,
+            self.microversion_id,
+            self.config.configuration,
+        )
+        self.features_by_key: dict = {top_key: self.features}
+
         for sub_assembly in self.assembly_data["subAssemblies"]:
             sub_features = self.client.get_features(
                 sub_assembly["documentId"],
@@ -356,6 +377,13 @@ class Assembly:
                 wmv="m",
                 configuration=sub_assembly["configuration"],
             )
+            sub_key = (
+                sub_assembly["documentId"],
+                sub_assembly["elementId"],
+                sub_assembly["documentMicroversion"],
+                sub_assembly["configuration"],
+            )
+            self.features_by_key[sub_key] = sub_features
             self.features["features"] += sub_features["features"]
 
         self.matevalues = self.client.matevalues(
@@ -576,6 +604,7 @@ class Assembly:
                     joint_type,
                     T_world_mate,
                     limits,
+                    prefix=tuple(prefix),
                 )
 
                 if data["inverted"]:
@@ -886,21 +915,79 @@ class Assembly:
 
         return groups
 
-    def get_feature_by_id(self, feature_id: str):
+    def iter_all_parametric_features(
+        self, prefix: list = [], key: tuple = None, instances: list = None
+    ):
         """
-        Find a specific feature by its ID
+        Recursively yield (prefix, features_list, feature) for every
+        parametric feature (as returned by the Onshape "features" endpoint --
+        distinct from the mate/occurrence data iter_all_features walks)
+        found in the top-level assembly and every nested sub-assembly
+        instance, mirroring iter_all_features' recursion. `features_list` is
+        the full list `feature` came from, so a feature-id lookup (feature
+        ids are only unique within one document) can be scoped to the
+        correct document instead of colliding across sub-assemblies.
         """
-        for feature in self.features["features"]:
+        if key is None:
+            key = (
+                self.document_id,
+                self.element_id,
+                self.microversion_id,
+                self.config.configuration,
+            )
+        if instances is None:
+            instances = self.assembly_data["rootAssembly"]["instances"]
+
+        features = self.features_by_key.get(key, {"features": []})["features"]
+        for feature in features:
+            yield prefix, features, feature
+
+        for instance in instances:
+            if instance.get("type") == "Assembly" and not instance["suppressed"]:
+                sub_assembly = self.find_sub_assembly(instance)
+                if sub_assembly is not None:
+                    sub_key = (
+                        sub_assembly["documentId"],
+                        sub_assembly["elementId"],
+                        sub_assembly["documentMicroversion"],
+                        sub_assembly["configuration"],
+                    )
+                    yield from self.iter_all_parametric_features(
+                        prefix + [instance["id"]], sub_key, sub_assembly["instances"]
+                    )
+
+    def get_feature_by_id(self, features: list, feature_id: str):
+        """
+        Find a specific feature by its ID within a given features list (a
+        feature id is only unique within the one document it came from).
+        """
+        for feature in features:
             if feature["message"]["featureId"] == feature_id:
                 return feature
 
         return None
 
+    def find_dof(self, prefix: tuple, name: str):
+        """
+        Find the DOF discovered at an exact prefix (sub-assembly instance)
+        with a given (dof_-stripped) name.
+        """
+        for dof in self.dofs:
+            if dof.prefix == prefix and dof.name == name:
+                return dof
+        return None
+
     def find_relations(self):
         """
-        Finding relations features in the assembly
+        Finding relations features in the assembly, anywhere in the document
+        tree. A relation is resolved against the DOFs found at the exact same
+        prefix (sub-assembly instance) it was itself found in, so that a
+        sub-assembly instanced more than once (e.g. three legs sharing one
+        leg sub-assembly) gets one independently-correct relation per
+        instance, instead of every instance's target mimicking the same
+        single (first-found) source joint.
         """
-        for feature in self.features["features"]:
+        for prefix, features, feature in self.iter_all_parametric_features():
             if feature["typeName"] == "BTMMateRelation":
                 relation_name = feature["message"]["name"]
 
@@ -912,10 +999,10 @@ class Assembly:
                         queries = parameter["message"]["queries"]
                         if len(queries) == 2:
                             dof1_feature = self.get_feature_by_id(
-                                queries[0]["message"]["featureId"]
+                                features, queries[0]["message"]["featureId"]
                             )
                             dof2_feature = self.get_feature_by_id(
-                                queries[1]["message"]["featureId"]
+                                features, queries[1]["message"]["featureId"]
                             )
                             if dof1_feature is not None and dof2_feature is not None:
                                 dof1 = dof1_feature["message"]["name"]
@@ -931,19 +1018,27 @@ class Assembly:
                     if not reverse:
                         ratio = -ratio
 
+                    prefix_tuple = tuple(prefix)
+                    source_dof = self.find_dof(prefix_tuple, mated_dofs[0])
+                    target_dof = self.find_dof(prefix_tuple, mated_dofs[1])
+
+                    if source_dof is None or target_dof is None:
+                        continue
+
                     print(
                         success(
-                            f"+ Found relation {relation_name} mating {mated_dofs} with ratio {ratio}"
+                            f"+ Found relation {relation_name} mating {mated_dofs} "
+                            f"with ratio {ratio} (prefix {prefix_tuple})"
                         )
                     )
-                    if mated_dofs[1] in self.relations:
+                    if id(target_dof) in self.relations:
                         print(
                             warning(
                                 f"Multiple relations found with {mated_dofs[1]} as target"
                             )
                         )
 
-                    self.relations[mated_dofs[1]] = [mated_dofs[0], ratio]
+                    self.relations[id(target_dof)] = (id(source_dof), ratio)
 
     def read_parameter_value(self, parameter: str, name: str):
         """

--- a/onshape_to_robot/assembly.py
+++ b/onshape_to_robot/assembly.py
@@ -419,6 +419,22 @@ class Assembly:
             if dof.body2_id == body2_id:
                 dof.body2_id = body1_id
 
+    def resolve_body_id(self, path: list):
+        """
+        Resolve the body id owning a given occurrence path, walking from the
+        most specific (full path) to the least specific (top-level only)
+        registered ancestor. This lets occurrences never individually
+        merged/mated (e.g. unmated fasteners nested inside a sub-assembly)
+        inherit the body of whichever ancestor occurrence they belong to,
+        instead of only ever matching a bare top-level instance id.
+        """
+        path = tuple(path)
+        for length in range(len(path), 0, -1):
+            key = path[:length]
+            if key in self.instance_body:
+                return self.instance_body[key]
+        return None
+
     def translation(self, x: float, y: float, z: float) -> np.ndarray:
         return np.array(
             [
@@ -434,7 +450,7 @@ class Assembly:
         Pre-assign all top-level instances to a separate body id
         """
         top_level_instances = self.assembly_data["rootAssembly"]["instances"]
-        self.make_body(top_level_instances[0]["id"])
+        self.make_body((top_level_instances[0]["id"],))
 
         # We first search for DOFs
         for data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
@@ -570,8 +586,8 @@ class Assembly:
 
         # Checking that all intances are assigned to a body
         for instance in self.assembly_data["rootAssembly"]["instances"]:
-            if instance["id"] not in self.instance_body and not instance["suppressed"]:
-                self.make_body(instance["id"])
+            if (instance["id"],) not in self.instance_body and not instance["suppressed"]:
+                self.make_body((instance["id"],))
 
         # Processing loop closing frames
         for data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
@@ -580,7 +596,7 @@ class Assembly:
             if data["name"].startswith("closing_"):
                 for k in 0, 1:
                     mated_entity = data["matedEntities"][k]
-                    occurrence = mated_entity["matedOccurrence"][0]
+                    body_id = self.resolve_body_id(mated_entity["matedOccurrence"])
 
                     T_world_part = self.get_occurrence_transform(
                         mated_entity["matedOccurrence"]
@@ -590,7 +606,7 @@ class Assembly:
 
                     self.frames.append(
                         Frame(
-                            self.instance_body[occurrence],
+                            body_id,
                             f"{data['name']}_{k+1}",
                             T_world_mate,
                         )
@@ -599,7 +615,7 @@ class Assembly:
                     if is_hinge_closure:
                         self.frames.append(
                             Frame(
-                                self.instance_body[occurrence],
+                                body_id,
                                 f"{data['name']}_{k+1}_z",
                                 T_world_mate @ self.translation(0, 0, 0.1),
                             )
@@ -639,7 +655,7 @@ class Assembly:
                 "name"
             ].startswith("link_"):
                 link_name = "_".join(feature["featureData"]["name"].split("_")[1:])
-                body_id = self.instance_body[feature["featureData"]["occurrence"][0]]
+                body_id = self.resolve_body_id(feature["featureData"]["occurrence"])
                 self.link_names[body_id] = link_name
 
             if feature["featureType"] == "mateConnector" and feature["featureData"][
@@ -648,7 +664,7 @@ class Assembly:
                 name = "_".join(feature["featureData"]["name"].split("_")[1:])
                 occurrence = feature["featureData"]["occurrence"]
                 T_world_occurrence = self.get_occurrence_transform(occurrence)
-                body_id = self.instance_body[occurrence[0]]
+                body_id = self.resolve_body_id(occurrence)
                 T_occurrence_mate = self.cs_to_transformation(
                     feature["featureData"]["mateConnectorCS"]
                 )
@@ -665,6 +681,21 @@ class Assembly:
         for body_id in self.instance_body.values():
             if body_id != INSTANCE_IGNORE and body_id not in self.body_in_tree:
                 self.build_tree(body_id)
+
+        # Drop root nodes that carry no real geometry and have no children --
+        # these are the bare wrapper occurrence of a sub-assembly instance
+        # (an "Assembly" has no geometry of its own, only the parts nested
+        # inside it do), and would otherwise spuriously compete as separate
+        # "multiple base links" against the real, connected robot tree.
+        self.root_nodes = [
+            root
+            for root in self.root_nodes
+            if self.tree_children.get(root)
+            or any(
+                occurrence["instance"]["type"] == "Part"
+                for occurrence in self.body_occurrences(root)
+            )
+        ]
 
         print(success(f"* Found {len(self.root_nodes)} root nodes:"))
         for root_node in self.root_nodes:
@@ -722,8 +753,8 @@ class Assembly:
                 ):
                     continue
 
-                occurrence_A = data["matedEntities"][0]["matedOccurrence"][0]
-                occurrence_B = data["matedEntities"][1]["matedOccurrence"][0]
+                occurrence_A = tuple(data["matedEntities"][0]["matedOccurrence"])
+                occurrence_B = tuple(data["matedEntities"][1]["matedOccurrence"])
 
                 yield data, occurrence_A, occurrence_B
 
@@ -739,7 +770,7 @@ class Assembly:
                 data = feature["featureData"]
 
                 for occurrence in data["occurrences"]:
-                    group.append(occurrence["occurrence"][0])
+                    group.append(tuple(occurrence["occurrence"]))
             groups.append(group)
 
         return groups
@@ -920,12 +951,9 @@ class Assembly:
         """
         Get the (first) instance associated with a given body
         """
-        for instance in self.assembly_data["rootAssembly"]["instances"]:
-            if (
-                instance["id"] in self.instance_body
-                and self.instance_body[instance["id"]] == body_id
-            ):
-                return instance
+        for occurrence in self.assembly_data["rootAssembly"]["occurrences"]:
+            if self.resolve_body_id(occurrence["path"]) == body_id:
+                return self.get_occurrence(occurrence["path"])["instance"]
 
         return None
 
@@ -934,8 +962,7 @@ class Assembly:
         Retrieve all occurrences associated to a given body id
         """
         for occurrence in self.assembly_data["rootAssembly"]["occurrences"]:
-            key = occurrence["path"][0]
-            if key in self.instance_body and self.instance_body[key] == body_id:
+            if self.resolve_body_id(occurrence["path"]) == body_id:
                 yield occurrence
 
     def get_dof(self, body1_id: int, body2_id: int):

--- a/onshape_to_robot/assembly.py
+++ b/onshape_to_robot/assembly.py
@@ -113,6 +113,14 @@ class Assembly:
         # membership for connectivity purposes, while still using their own
         # real position for geometry.
         self.pattern_seed_of: dict[str, str] = {}
+        # Tracks how many times a given name has been used across every
+        # user-named "frame_"/"closing_"/"link_" mate or mate connector, so
+        # repeated sub-assembly instances (e.g. three legs sharing one leg
+        # sub-assembly) don't collide on the same name -- which would
+        # otherwise produce duplicate <link> elements in the exported URDF,
+        # since frames and link-name overrides share the same link
+        # namespace as regular body links.
+        self._global_name_count: dict[str, int] = {}
 
         self.ensure_workspace_or_version()
         self.find_assembly()
@@ -126,6 +134,16 @@ class Assembly:
         self.build_trees()
         self.find_relations()
         print("")
+
+    def unique_global_name(self, name: str) -> str:
+        """
+        Returns a name guaranteed to be unique across all frame/link names created
+        so far, disambiguating repeated names (e.g. from repeated sub-assembly
+        instances) by appending "_2", "_3", etc.
+        """
+        count = self._global_name_count.get(name, 0) + 1
+        self._global_name_count[name] = count
+        return name if count == 1 else f"{name}_{count}"
 
     def ensure_workspace_or_version(self):
         """
@@ -633,7 +651,7 @@ class Assembly:
         # Processing frame mates
         for prefix, data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
             if data["name"].startswith("frame_"):
-                name = "_".join(data["name"].split("_")[1:])
+                name = self.unique_global_name("_".join(data["name"].split("_")[1:]))
                 if (
                     occurrence_A not in self.instance_body
                     and occurrence_B in self.instance_body
@@ -675,6 +693,9 @@ class Assembly:
             is_hinge_closure = data["mateType"] == "REVOLUTE"
 
             if data["name"].startswith("closing_"):
+                frame_names: dict[int, str] = {}
+                z_names: dict[int, str] = {}
+
                 for k in 0, 1:
                     mated_entity = data["matedEntities"][k]
                     body_id = self.resolve_body_id(prefix + mated_entity["matedOccurrence"])
@@ -685,19 +706,17 @@ class Assembly:
                     T_part_mate = self.get_mate_transform(mated_entity)
                     T_world_mate = T_world_part @ T_part_mate
 
-                    self.frames.append(
-                        Frame(
-                            body_id,
-                            f"{data['name']}_{k+1}",
-                            T_world_mate,
-                        )
-                    )
+                    frame_name = self.unique_global_name(f"{data['name']}_{k+1}")
+                    frame_names[k] = frame_name
+                    self.frames.append(Frame(body_id, frame_name, T_world_mate))
 
                     if is_hinge_closure:
+                        z_name = f"{frame_name}_z"
+                        z_names[k] = z_name
                         self.frames.append(
                             Frame(
                                 body_id,
-                                f"{data['name']}_{k+1}_z",
+                                z_name,
                                 T_world_mate @ self.translation(0, 0, 0.1),
                             )
                         )
@@ -712,16 +731,16 @@ class Assembly:
                 self.closures.append(
                     [
                         closure_types.get(data["mateType"], "unknown"),
-                        f"{data['name']}_1",
-                        f"{data['name']}_2",
+                        frame_names[0],
+                        frame_names[1],
                     ]
                 )
                 if is_hinge_closure:
                     self.closures.append(
                         [
                             closure_types.get(data["mateType"], "unknown"),
-                            f"{data['name']}_1_z",
-                            f"{data['name']}_2_z",
+                            z_names[0],
+                            z_names[1],
                         ]
                     )
 
@@ -735,7 +754,9 @@ class Assembly:
             if feature["featureType"] == "mateConnector" and feature["featureData"][
                 "name"
             ].startswith("link_"):
-                link_name = "_".join(feature["featureData"]["name"].split("_")[1:])
+                link_name = self.unique_global_name(
+                    "_".join(feature["featureData"]["name"].split("_")[1:])
+                )
                 occurrence = prefix + feature["featureData"]["occurrence"]
                 body_id = self.resolve_body_id(occurrence)
                 self.link_names[body_id] = link_name
@@ -743,7 +764,9 @@ class Assembly:
             if feature["featureType"] == "mateConnector" and feature["featureData"][
                 "name"
             ].startswith("frame_"):
-                name = "_".join(feature["featureData"]["name"].split("_")[1:])
+                name = self.unique_global_name(
+                    "_".join(feature["featureData"]["name"].split("_")[1:])
+                )
                 occurrence = prefix + feature["featureData"]["occurrence"]
                 T_world_occurrence = self.get_occurrence_transform(occurrence)
                 body_id = self.resolve_body_id(occurrence)

--- a/onshape_to_robot/assembly.py
+++ b/onshape_to_robot/assembly.py
@@ -298,7 +298,9 @@ class Assembly:
 
     def load_features(self):
         """
-        Load features
+        Load features, also fetching the parametric features of every nested
+        sub-assembly so mate limits and gear/mimic relations defined inside a
+        sub-assembly's own tab (not just the top-level assembly) are found.
         """
 
         self.features = self.client.get_features(
@@ -308,6 +310,16 @@ class Assembly:
             wmv="m",
             configuration=self.config.configuration,
         )
+
+        for sub_assembly in self.assembly_data["subAssemblies"]:
+            sub_features = self.client.get_features(
+                sub_assembly["documentId"],
+                sub_assembly["documentMicroversion"],
+                sub_assembly["elementId"],
+                wmv="m",
+                configuration=sub_assembly["configuration"],
+            )
+            self.features["features"] += sub_features["features"]
 
         self.matevalues = self.client.matevalues(
             self.document_id,
@@ -453,7 +465,7 @@ class Assembly:
         self.make_body((top_level_instances[0]["id"],))
 
         # We first search for DOFs
-        for data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
+        for prefix, data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
             if data["name"].startswith("dof_"):
                 # Process the DOF name, removing dof prefix and inv suffix
                 parts = data["name"].split("_")
@@ -498,7 +510,7 @@ class Assembly:
                 # We compute the axis in the world frame
                 mated_entity = data["matedEntities"][0]
                 T_world_part = self.get_occurrence_transform(
-                    mated_entity["matedOccurrence"]
+                    prefix + mated_entity["matedOccurrence"]
                 )
 
                 # jointToPart is the (rotation only) matrix from joint to the part
@@ -533,7 +545,7 @@ class Assembly:
                 self.dofs.append(dof)
 
         # Merging fixed links
-        for data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
+        for prefix, data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
             if data["name"].startswith("fix_") or (
                 data["mateType"] == "FASTENED"
                 and not data["name"].startswith("dof_")
@@ -551,7 +563,7 @@ class Assembly:
                 self.merge_bodies(occurrence_A, occurrence_B)
 
         # Processing frame mates
-        for data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
+        for prefix, data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
             if data["name"].startswith("frame_"):
                 name = "_".join(data["name"].split("_")[1:])
                 if (
@@ -572,7 +584,7 @@ class Assembly:
                     )
 
                 T_world_part = self.get_occurrence_transform(
-                    mated_entity["matedOccurrence"]
+                    prefix + mated_entity["matedOccurrence"]
                 )
 
                 self.frames.append(
@@ -590,16 +602,16 @@ class Assembly:
                 self.make_body((instance["id"],))
 
         # Processing loop closing frames
-        for data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
+        for prefix, data, occurrence_A, occurrence_B in self.feature_mating_two_occurrences():
             is_hinge_closure = data["mateType"] == "REVOLUTE"
 
             if data["name"].startswith("closing_"):
                 for k in 0, 1:
                     mated_entity = data["matedEntities"][k]
-                    body_id = self.resolve_body_id(mated_entity["matedOccurrence"])
+                    body_id = self.resolve_body_id(prefix + mated_entity["matedOccurrence"])
 
                     T_world_part = self.get_occurrence_transform(
-                        mated_entity["matedOccurrence"]
+                        prefix + mated_entity["matedOccurrence"]
                     )
                     T_part_mate = self.get_mate_transform(mated_entity)
                     T_world_mate = T_world_part @ T_part_mate
@@ -645,7 +657,7 @@ class Assembly:
                     )
 
         # Search for mate connector named "link_..." to override link names
-        for feature in self.assembly_data["rootAssembly"]["features"]:
+        for prefix, feature in self.iter_all_features():
             # Suppressed mate connectors reference occurrences that may no longer
             # exist in the assembly, so skip them like mates and mate groups do.
             if feature.get("suppressed"):
@@ -655,14 +667,15 @@ class Assembly:
                 "name"
             ].startswith("link_"):
                 link_name = "_".join(feature["featureData"]["name"].split("_")[1:])
-                body_id = self.resolve_body_id(feature["featureData"]["occurrence"])
+                occurrence = prefix + feature["featureData"]["occurrence"]
+                body_id = self.resolve_body_id(occurrence)
                 self.link_names[body_id] = link_name
 
             if feature["featureType"] == "mateConnector" and feature["featureData"][
                 "name"
             ].startswith("frame_"):
                 name = "_".join(feature["featureData"]["name"].split("_")[1:])
-                occurrence = feature["featureData"]["occurrence"]
+                occurrence = prefix + feature["featureData"]["occurrence"]
                 T_world_occurrence = self.get_occurrence_transform(occurrence)
                 body_id = self.resolve_body_id(occurrence)
                 T_occurrence_mate = self.cs_to_transformation(
@@ -737,11 +750,63 @@ class Assembly:
                 elif child not in exploring:
                     exploring.append(child)
 
+    def find_sub_assembly(self, instance: dict):
+        """
+        Find the subAssemblies[] entry matching a given Assembly-type instance
+        """
+        d = instance["documentId"]
+        m = instance["documentMicroversion"]
+        e = instance["elementId"]
+        c = instance["configuration"]
+        for sub_assembly in self.assembly_data["subAssemblies"]:
+            if (
+                sub_assembly["documentId"] == d
+                and sub_assembly["documentMicroversion"] == m
+                and sub_assembly["elementId"] == e
+                and sub_assembly["configuration"] == c
+            ):
+                return sub_assembly
+        return None
+
+    def iter_all_features(self, prefix: list = [], features: list = None, instances: list = None):
+        """
+        Recursively yield (prefix, feature) for every feature (mate,
+        mateConnector, mateGroup) found either directly in the given
+        assembly-like context or in any nested sub-assembly instance
+        underneath it. Called with no arguments, this walks the whole
+        document tree starting at the exported top-level assembly, so mates
+        authored inside a nested sub-assembly's own tab are discovered the
+        same way as ones authored at the top level -- letting a sub-assembly
+        stay independently articulable/testable on its own without needing
+        its mates duplicated at the top level for export. `prefix` is the
+        occurrence path leading to the sub-assembly instance a given feature
+        was found in (empty at the top level), needed to turn that feature's
+        own locally-relative occurrence references into full, unique paths.
+        """
+        if features is None:
+            features = self.assembly_data["rootAssembly"]["features"]
+        if instances is None:
+            instances = self.assembly_data["rootAssembly"]["instances"]
+
+        for feature in features:
+            yield prefix, feature
+
+        for instance in instances:
+            if instance.get("type") == "Assembly" and not instance["suppressed"]:
+                sub_assembly = self.find_sub_assembly(instance)
+                if sub_assembly is not None:
+                    yield from self.iter_all_features(
+                        prefix + [instance["id"]],
+                        sub_assembly["features"],
+                        sub_assembly["instances"],
+                    )
+
     def feature_mating_two_occurrences(self):
         """
-        Iterate over all valid mating feature with two occurrences
+        Iterate over all valid mating feature with two occurrences, anywhere
+        in the document tree (top-level assembly or any nested sub-assembly)
         """
-        for feature in self.assembly_data["rootAssembly"]["features"]:
+        for prefix, feature in self.iter_all_features():
             if feature["featureType"] == "mate" and not feature["suppressed"]:
                 data = feature["featureData"]
 
@@ -753,24 +818,24 @@ class Assembly:
                 ):
                     continue
 
-                occurrence_A = tuple(data["matedEntities"][0]["matedOccurrence"])
-                occurrence_B = tuple(data["matedEntities"][1]["matedOccurrence"])
+                occurrence_A = tuple(prefix + data["matedEntities"][0]["matedOccurrence"])
+                occurrence_B = tuple(prefix + data["matedEntities"][1]["matedOccurrence"])
 
-                yield data, occurrence_A, occurrence_B
+                yield prefix, data, occurrence_A, occurrence_B
 
     def feature_mate_groups(self):
         """
-        Find mate groups in the assembly
+        Find mate groups in the assembly, anywhere in the document tree
         """
         groups = []
 
-        for feature in self.assembly_data["rootAssembly"]["features"]:
+        for prefix, feature in self.iter_all_features():
             group = []
             if feature["featureType"] == "mateGroup" and not feature["suppressed"]:
                 data = feature["featureData"]
 
                 for occurrence in data["occurrences"]:
-                    group.append(tuple(occurrence["occurrence"]))
+                    group.append(tuple(prefix + occurrence["occurrence"]))
             groups.append(group)
 
         return groups

--- a/onshape_to_robot/robot_builder.py
+++ b/onshape_to_robot/robot_builder.py
@@ -22,10 +22,23 @@ class RobotBuilder:
 
         self.unique_names = {}
         self.stl_filenames: dict = {}
+        # Maps a DOF's identity (id(dof)) to the Joint built from it, filled
+        # in as joints are created below. Needed because self.assembly.relations
+        # is keyed by DOF identity too (not name), and a relation's source
+        # joint may not have been built/given its final disambiguated name
+        # yet at the point its target is -- so relations are applied in a
+        # second pass, once every joint that could be a source has one.
+        self.joint_for_dof_id: dict = {}
 
         for node in self.assembly.root_nodes:
             link = self.build_robot(node)
             self.robot.base_links.append(link)
+
+        for target_dof_id, (source_dof_id, ratio) in self.assembly.relations.items():
+            target_joint = self.joint_for_dof_id.get(target_dof_id)
+            source_joint = self.joint_for_dof_id.get(source_dof_id)
+            if target_joint is not None and source_joint is not None:
+                target_joint.relation = Relation(source_joint.name, ratio)
 
     def part_is_ignored(self, name: str, what: str) -> bool:
         """
@@ -132,6 +145,27 @@ class RobotBuilder:
 
             if name not in [frame.name for frame in self.assembly.frames]:
                 return name
+
+    def unique_joint_name(self, name: str) -> str:
+        """
+        Get a unique joint name (hip, hip_2, hip_3, ...). Joints discovered
+        from a sub-assembly that is itself instanced multiple times (e.g.
+        three copies of the same leg) would otherwise all share the exact
+        same base name, since the underlying mate is only defined once in
+        the sub-assembly's own document. Matching against config-driven
+        joint_properties patterns and gear/mimic relations still uses the
+        original (pre-disambiguation) name, so those keep working the same
+        way they did before this only mattered for repeated sub-assemblies.
+        """
+        if "joint" not in self.unique_names:
+            self.unique_names["joint"] = {}
+
+        if name in self.unique_names["joint"]:
+            self.unique_names["joint"][name] += 1
+            return f"{name}_{self.unique_names['joint'][name]}"
+        else:
+            self.unique_names["joint"][name] = 1
+            return name
 
     def instance_request_params(self, instance: dict) -> dict:
         """
@@ -434,7 +468,7 @@ class RobotBuilder:
                     }
 
             joint = Joint(
-                dof.name,
+                self.unique_joint_name(dof.name),
                 dof.joint_type,
                 link,
                 None,
@@ -443,9 +477,7 @@ class RobotBuilder:
                 dof.limits,
                 dof.axis,
             )
-            if dof.name in self.assembly.relations:
-                source, ratio = self.assembly.relations[dof.name]
-                joint.relation = Relation(source, ratio)
+            self.joint_for_dof_id[id(dof)] = joint
 
             # The joint is added before the recursive call, ensuring items in robot.joints has the
             # same order as recursive calls on the tree


### PR DESCRIPTION
## Problem

Building a legged robot in Onshape, I structured each leg as its own sub-assembly (so it stays independently mate-able/testable on its own, rather than living flat inside the top-level assembly). All the `dof_`/`fix_` mates for a leg's joints were authored inside that leg's own sub-assembly document, then the sub-assembly was instanced multiple times (once per leg) under the top-level exported assembly.

This hit two separate problems:

**1. Mates inside a sub-assembly are invisible to the exporter.** `feature_mating_two_occurrences()`/`feature_mate_groups()`/`process_mates()`'s mateConnector handling only ever read `assembly_data["rootAssembly"]["features"]` — the top-level assembly's own local feature list. A mate authored inside a sub-assembly's own tab was never found (0 DOFs detected), even though `get_assembly()` already returns each sub-assembly's own local `features` list in the same response (`subAssemblies[i]["features"]`) — no extra API call needed.

**2. Working around (1) by duplicating the mates at the top level hits a second, unrelated bug.** If you instead re-create the same mates directly in the top-level assembly (reaching into the sub-assembly's parts), body/occurrence identity is derived from only the *first element* of the occurrence path (`data["matedEntities"][0]["matedOccurrence"][0]`, `occurrence["path"][0]`, etc.). For a mate connecting two different parts nested inside the *same* sub-assembly instance, both occurrences share that same first path element — so two unrelated parts, each independently mated via their own named `dof_` mate, silently collapse onto the same body-identity key. The exporter then reports a fabricated closed-loop (`"The DOF graph is not a tree, check for loops in your DOFs"`) for a perfectly valid, loop-free assembly.

Together these meant there was no way to keep a sub-assembly's mates in its own document (independently testable) *and* have it export correctly.

## Fix

Four commits, each addressing one piece:

1. **`295c2a7`** — Use the full occurrence path (already the existing convention for `self.occurrences`) everywhere a body identity is derived, instead of just its first element. Adds `resolve_body_id()`, which walks from the most specific to least specific registered ancestor (so unmated fasteners etc. still correctly inherit their nearest ancestor's body). One side effect: a sub-assembly instance's bare wrapper occurrence (no geometry of its own) can now end up its own empty, disconnected body — `build_trees()` now drops root nodes with neither children nor real part geometry.
2. **`cc128e7`** — `iter_all_features()` recursively walks the instance tree (mirroring `find_instances()`) so mates/mateConnectors/mateGroups authored inside any nested sub-assembly are discovered the same way as top-level ones, with the occurrence path prefix needed to resolve their local references. `load_features()` also pulls in each sub-assembly's parametric features, for limits/relations.
3. **`bb3d137`** — Onshape's Pattern feature creates copies via a geometric transform only, no mate of their own. A patterned copy of an individually-mated part (e.g. a bracket circular-patterned 3x, each copy then separately mated to a different leg) had no mate tying it back to its rigid group. `load_patterns()` + `canonicalize_occurrence()` make a copy resolve to the same body as its seed, using `get_assembly()`'s existing `seedToPatternInstances` data.
4. **`858cd18`** — Two more per-instance issues once sub-assemblies are properly instanced multiple times: joint names collided (three legs' "hip" joint all named `hip`) — fixed with the same disambiguation link names already had (`unique_joint_name()`). Gear/mimic relations collided even harder: a relation defined once in a shared sub-assembly document made every instance's target mimic the literal same first-found source joint. `DOF` now tracks its discovery prefix, `find_relations()` resolves each relation against DOFs at that same prefix, and `self.relations` is keyed by DOF identity rather than name (with a two-pass build in `RobotBuilder` so a relation's source has its final disambiguated name by the time it's needed, regardless of tree traversal order).

## Testing

Validated end-to-end against a real hexapod-style robot: 3 sub-assembly instances of a 3-DOF leg (hip/knee/ankle) and 3 sub-assembly instances of a 1-DOF leg (paired-actuator anchor mechanism with a closed 4-bar linkage, gear-related master/follower motors, and circular-patterned mounting hardware), all mates kept entirely within each sub-assembly's own document. Confirmed:
- Correct DOF count and a single, fully-connected tree (no phantom multi-root warnings).
- Each leg's joints get correctly disambiguated names (`3DOF_hip`, `3DOF_hip_2`, `3DOF_hip_3`, ...).
- Each leg's gear relation resolves independently (`<mimic joint="1DOF_master_2" .../>` for leg 2, not leg 1's joint).
- Patterned mounting hardware correctly merges into its seed's rigid body.
- Isolated minimal repro (single mate, both mated parts nested under the same sub-assembly instance) reproduces the original "not a tree" bug on `master`, and passes cleanly on this branch.

Also spot-checked in RViz against the exported URDF/meshes — full robot renders and articulates correctly, mimic joints included.